### PR TITLE
[OT-211] [FEAT]: reissueApi를 통한 Token 재발급

### DIFF
--- a/src/shared/api/apiClient.ts
+++ b/src/shared/api/apiClient.ts
@@ -1,5 +1,6 @@
-import axios from "axios";
+import axios, { InternalAxiosRequestConfig } from "axios";
 import { ApiError } from "@shared/types";
+import { reissueApi } from "./reissueApi";
 
 const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
@@ -12,22 +13,61 @@ export const api = axios.create({
   withCredentials: true,
 });
 
+let isRefreshing = false;
+let failedQueue: Array<{
+  resolve: () => void;
+  reject: (reason: unknown) => void;
+}> = [];
+
+const processQueue = (error: unknown) => {
+  failedQueue.forEach(({ resolve, reject }) => {
+    if (error) {
+      reject(error);
+    } else {
+      resolve();
+    }
+  });
+  failedQueue = [];
+};
+
 api.interceptors.response.use(
   (response) => response,
-  (error) => {
+  async (error) => {
     if (!axios.isAxiosError(error)) {
       return Promise.reject(error);
     }
 
+    const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
     const apiError = error.response?.data as ApiError | undefined;
 
-    if (error.response?.status === 401) {
-      if (typeof window !== "undefined") {
-        if (!window.location.pathname.includes("/auth/login")) {
-          window.location.href = "/auth/login";
-        }
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      if (isRefreshing) {
+        console.log("[Token 재발급] 이미 갱신 중 → 대기열 추가");
+        return new Promise<void>((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then(() => api(originalRequest))
+          .catch((err) => Promise.reject(err));
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+      console.log("[Token 재발급] 갱신 시작");
+
+      try {
+        await reissueApi.refresh();
+        console.log("[Token 재발급] 성공 → 원래 요청 재시도");
+        processQueue(null);
+        return api(originalRequest);
+      } catch (refreshError) {
+        console.error("[Token 재발급] 실패 → 현재 페이지 유지", refreshError);
+        processQueue(refreshError);
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
       }
     }
+
     if (apiError) {
       return Promise.reject(apiError);
     }

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,1 +1,2 @@
 export { api } from "./apiClient";
+export { reissueApi } from "./reissueApi";

--- a/src/shared/api/reissueApi.ts
+++ b/src/shared/api/reissueApi.ts
@@ -1,0 +1,15 @@
+import axios from "axios";
+
+const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+const reissueClient = axios.create({
+  baseURL,
+  withCredentials: true,
+  headers: { "Content-Type": "application/json" },
+});
+
+export const reissueApi = {
+  refresh: async (): Promise<void> => {
+    await reissueClient.post("/reissue", null);
+  },
+};


### PR DESCRIPTION
## 📝 작업 내용

> reissueApi를 통한 accessToken 재발급 과정

- [x] reissueAPI 연동
- [x] accessToken이 만료될때, 재발급과정 테스트

## 📷 스크린샷

| 구현 내용 |             reissueTest              |   
| :-------: | :-------------------------: | 
|    GIF    | <img src = "https://github.com/user-attachments/assets/3269b581-4e33-40db-b872-a1dd2f0c4c03" width ="1400"> | 

## 🖥️ 주요 코드 설명

`reissueApi.ts`

- Axios interceptor에서 401 에러 발생 시 자동으로 `/reissue` 호출 후 원래 요청 재시도
- 동시 다발적 401 에러 시 대기 큐(failedQueue)로 관리하여 `/reissue` 중복 호출 방지
- `reissueApi`는 별도 axios 인스턴스 사용으로 무한 루프 방지 (interceptor 미적용)

```ts
const reissueClient = axios.create({
  baseURL,
  withCredentials: true,
  headers: { "Content-Type": "application/json" },
});
```

## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #15 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * API 요청 실패 시 자동 토큰 새로고침 기능 추가
  * 토큰 만료로 인한 요청 실패 시 자동으로 토큰을 갱신하고 요청을 재시도
  * 여러 요청이 동시에 실패할 경우 효율적으로 처리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->