### PR TITLE
[OT-213] [FEAT]: 시리즈 관리 API 연동

### DIFF
--- a/src/entities/series/apis/fixSeriesApi.ts
+++ b/src/entities/series/apis/fixSeriesApi.ts
@@ -1,0 +1,31 @@
+import { api } from "@shared/api";
+import { ApiResponse, PublicStatus } from "@shared/types";
+
+export interface FixSeriesRequest {
+  seriesId: number;
+  title: string;
+  description: string;
+  actors: string;
+  publicStatus: PublicStatus;
+  categoryId: number;
+  tagIdList: number[];
+  posterFileName?: string;
+  thumbnailFileName?: string;
+}
+
+export interface FixSeriesResponse {
+  seriesId: number;
+  posterObjectKey?: string;
+  thumbnailObjectKey?: string;
+  posterUploadUrl?: string;
+  thumbnailUploadUrl?: string;
+}
+
+export const fixSeriesApi = async ({ seriesId, ...body }: FixSeriesRequest) => {
+  console.log("[fixSeriesApi] seriesId:", seriesId, "body:", body);
+  const res = await api.patch<ApiResponse<FixSeriesResponse>>(
+    `admin/series/${seriesId}/upload`,
+    body,
+  );
+  return res.data.data;
+};

--- a/src/entities/series/apis/getSeriesApi.ts
+++ b/src/entities/series/apis/getSeriesApi.ts
@@ -1,0 +1,37 @@
+import { api } from "@/shared/api";
+import {
+  ApiResponse,
+  BasePaginationParams,
+  Category,
+  PageInfo,
+  PublicStatus,
+} from "@shared/types";
+
+export interface SeriesListItem {
+  mediaId: number;
+  thumbnailUrl: string;
+  posterUrl: string;
+  title: string;
+  categoryName: Category;
+  tagNameList: string[];
+  publicStatus: PublicStatus;
+}
+
+export interface SeriesListResponse {
+  pageInfo: PageInfo;
+  dataList: SeriesListItem[];
+}
+
+export interface GetSeriesListParams extends BasePaginationParams {
+  page: number;
+  size: number;
+  searchWord?: string;
+}
+
+export const getSeriesListApi = async (params: GetSeriesListParams) => {
+  const res = await api.get<ApiResponse<SeriesListResponse>>(
+    "admin/series",
+    { params },
+  );
+  return res.data.data;
+};

--- a/src/entities/series/apis/getSeriesDetailApi.ts
+++ b/src/entities/series/apis/getSeriesDetailApi.ts
@@ -1,0 +1,23 @@
+import { api } from "@/shared/api";
+import { ApiResponse, Category, PublicStatus } from "@shared/types";
+
+export interface SeriesDetail {
+  seriesId: number;
+  title: string;
+  description: string;
+  categoryName: Category;
+  tagNameList: string[];
+  publicStatus: PublicStatus;
+  uploaderNickname: string;
+  bookmarkCount: number;
+  actors: string;
+  posterUrl: string;
+  thumbnailUrl: string;
+}
+
+export const getSeriesDetailApi = async (mediaId: number) => {
+  const res = await api.get<ApiResponse<SeriesDetail>>(
+    `admin/series/${mediaId}`,
+  );
+  return res.data.data;
+};

--- a/src/entities/series/apis/index.ts
+++ b/src/entities/series/apis/index.ts
@@ -1,2 +1,4 @@
 export { getSeriesListApi } from "./getSeriesApi";
 export type { SeriesListItem, SeriesListResponse, GetSeriesListParams } from "./getSeriesApi";
+export { getSeriesDetailApi } from "./getSeriesDetailApi";
+export type { SeriesDetail } from "./getSeriesDetailApi";

--- a/src/entities/series/apis/index.ts
+++ b/src/entities/series/apis/index.ts
@@ -2,3 +2,5 @@ export { getSeriesListApi } from "./getSeriesApi";
 export type { SeriesListItem, SeriesListResponse, GetSeriesListParams } from "./getSeriesApi";
 export { getSeriesDetailApi } from "./getSeriesDetailApi";
 export type { SeriesDetail } from "./getSeriesDetailApi";
+export { uploadSeriesApi } from "./uploadSeriesApi";
+export type { UploadSeriesRequest, UploadSeriesResponse } from "./uploadSeriesApi";

--- a/src/entities/series/apis/index.ts
+++ b/src/entities/series/apis/index.ts
@@ -1,0 +1,2 @@
+export { getSeriesListApi } from "./getSeriesApi";
+export type { SeriesListItem, SeriesListResponse, GetSeriesListParams } from "./getSeriesApi";

--- a/src/entities/series/apis/index.ts
+++ b/src/entities/series/apis/index.ts
@@ -4,3 +4,5 @@ export { getSeriesDetailApi } from "./getSeriesDetailApi";
 export type { SeriesDetail } from "./getSeriesDetailApi";
 export { uploadSeriesApi } from "./uploadSeriesApi";
 export type { UploadSeriesRequest, UploadSeriesResponse } from "./uploadSeriesApi";
+export { fixSeriesApi } from "./fixSeriesApi";
+export type { FixSeriesRequest, FixSeriesResponse } from "./fixSeriesApi";

--- a/src/entities/series/apis/uploadSeriesApi.ts
+++ b/src/entities/series/apis/uploadSeriesApi.ts
@@ -1,0 +1,29 @@
+import { api } from "@shared/api";
+import { ApiResponse, PublicStatus } from "@shared/types";
+
+export interface UploadSeriesRequest {
+  title: string;
+  description: string;
+  actors: string;
+  publicStatus: PublicStatus;
+  categoryId: number;
+  tagIdList: number[];
+  posterFileName: string;
+  thumbnailFileName: string;
+}
+
+export interface UploadSeriesResponse {
+  seriesId: number;
+  posterObjectKey: string;
+  thumbnailObjectKey: string;
+  posterUploadUrl: string;
+  thumbnailUploadUrl: string;
+}
+
+export const uploadSeriesApi = async (body: UploadSeriesRequest) => {
+  const res = await api.post<ApiResponse<UploadSeriesResponse>>(
+    "admin/series/upload",
+    body,
+  );
+  return res.data.data;
+};

--- a/src/entities/series/components/AdminSeriesDetailModal.tsx
+++ b/src/entities/series/components/AdminSeriesDetailModal.tsx
@@ -3,20 +3,26 @@
 import Image from "next/image";
 import { Bookmark, X } from "lucide-react";
 import { CategoryBadge } from "@entities/category/components";
+import { useCategories } from "@entities/category/hooks";
+import { useSeriesDetail } from "@entities/series/hooks";
 import { TagBadge } from "@entities/tag/components";
 import { AdminPublicBadge } from "@shared/components";
-import { AdminSeries } from "@shared/mocks/mockAdminSeries";
 
 interface AdminSeriesDetailModalProps {
-  series: AdminSeries | null;
+  mediaId: number;
   onClose: () => void;
 }
 
 export function AdminSeriesDetailModal({
-  series,
+  mediaId,
   onClose,
 }: AdminSeriesDetailModalProps) {
-  if (!series) return null;
+  const { data: series, isLoading, isError } = useSeriesDetail(mediaId);
+  const { data: categories } = useCategories();
+
+  const categoryId =
+    categories?.find((c) => c.categoryName === series?.categoryName)
+      ?.categoryId ?? null;
 
   return (
     <div
@@ -37,106 +43,133 @@ export function AdminSeriesDetailModal({
           </button>
         </div>
 
-        {/* 썸네일 */}
-        <section className="flex flex-col gap-2">
-          <p className="text-base text-ot-background font-semibold">썸네일</p>
-          <div className="flex gap-3">
-            <div className="flex flex-col gap-1 ">
-              <p className="text-sm text-ot-background">세로 (5:7)</p>
-              <div className="relative w-60 aspect-5/7 rounded-lg overflow-hidden">
-                <Image
-                  src={series.posterUrl}
-                  alt={`${series.title} 세로 썸네일`}
-                  fill
-                  className="object-cover"
-                />
-              </div>
-            </div>
-            <div className="flex flex-col gap-1">
-              <p className="text-sm text-ot-background">가로 (4:3)</p>
-              <div className="relative w-113 aspect-4/3 rounded-lg overflow-hidden">
-                <Image
-                  src={series.thumbnailUrl}
-                  alt={`${series.title} 가로 썸네일`}
-                  fill
-                  className="object-cover"
-                />
-              </div>
-            </div>
-          </div>
-        </section>
+        {isLoading && <p className="text-ot-background">불러오는 중...</p>}
+        {isError && (
+          <p className="text-ot-background">데이터를 불러오지 못했습니다.</p>
+        )}
 
-        {/* 시리즈 제목 */}
-        <section className="flex flex-col gap-1">
-          <p className="text-base text-ot-background font-semibold">
-            시리즈 제목
-          </p>
-          <p className="text-sm font-semibold text-ot-background">
-            {series.title}
-          </p>
-        </section>
-
-        {/* 설명 */}
-        <section className="flex flex-col gap-1">
-          <p className="text-base text-ot-background font-semibold">설명</p>
-          <p className="text-sm text-ot-background leading-relaxed">
-            {series.description}
-          </p>
-        </section>
-
-        {/* 카테고리 / 태그 / 공개여부 */}
-        <section className="flex gap-6">
-          <div className="flex flex-col gap-1">
-            <p className="text-base text-ot-background font-semibold">
-              카테고리
-            </p>
-            <CategoryBadge category={series.category} />
-          </div>
-
-          <div className="flex flex-col gap-1">
-            <p className="text-base text-ot-background font-semibold">태그</p>
-            <div className="flex flex-wrap gap-1">
-              {series.tags.map((tag) => (
-                <TagBadge key={tag} label={tag} category={series.category} />
-              ))}
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-1">
-            <p className="text-base text-ot-background font-semibold">
-              공개여부
-            </p>
-            <AdminPublicBadge
-              context="modal"
-              isPublic={series.isPublic ? true : false}
-            />
-          </div>
-        </section>
-
-        {/* 업로더 / 북마크 / 출연 */}
-        <section className="flex gap-6">
-          <div className="flex flex-col gap-1">
-            <p className="text-base text-ot-background font-semibold">업로더</p>
-            <p className="text-sm text-ot-background">{series.uploader}</p>
-          </div>
-
-          <div className="flex flex-col gap-1">
-            <p className="text-base text-ot-background font-semibold">북마크</p>
-            <p className="text-sm text-ot-background flex items-center gap-1">
-              <Bookmark size={14} />
-              {series.bookmarkCount.toLocaleString()}
-            </p>
-          </div>
-
-          {series.cast.length > 0 && (
-            <div className="flex flex-col gap-1">
-              <p className="text-base text-ot-background font-semibold">출연</p>
-              <p className="text-sm text-ot-background">
-                {series.cast.join(", ")}
+        {series && (
+          <>
+            {/* 썸네일 */}
+            <section className="flex flex-col gap-2">
+              <p className="text-base text-ot-background font-semibold">
+                썸네일
               </p>
-            </div>
-          )}
-        </section>
+              <div className="flex gap-3">
+                <div className="flex flex-col gap-1">
+                  <p className="text-sm text-ot-background">세로 (5:7)</p>
+                  <div className="relative w-60 aspect-5/7 rounded-lg overflow-hidden">
+                    {/* <Image
+                      src={series.posterUrl}
+                      alt={`${series.title} 세로 썸네일`}
+                      fill
+                      className="object-cover"
+                    /> */}
+                  </div>
+                </div>
+                <div className="flex flex-col gap-1">
+                  <p className="text-sm text-ot-background">가로 (4:3)</p>
+                  <div className="relative w-113 aspect-4/3 rounded-lg overflow-hidden">
+                    {/* <Image
+                      src={series.thumbnailUrl}
+                      alt={`${series.title} 가로 썸네일`}
+                      fill
+                      className="object-cover"
+                    /> */}
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            {/* 시리즈 제목 */}
+            <section className="flex flex-col gap-1">
+              <p className="text-base text-ot-background font-semibold">
+                시리즈 제목
+              </p>
+              <p className="text-sm font-semibold text-ot-background">
+                {series.title}
+              </p>
+            </section>
+
+            {/* 설명 */}
+            <section className="flex flex-col gap-1">
+              <p className="text-base text-ot-background font-semibold">
+                설명
+              </p>
+              <p className="text-sm text-ot-background leading-relaxed">
+                {series.description}
+              </p>
+            </section>
+
+            {/* 카테고리 / 태그 / 공개여부 */}
+            <section className="flex gap-6">
+              <div className="flex flex-col gap-1">
+                <p className="text-base text-ot-background font-semibold">
+                  카테고리
+                </p>
+                {categoryId !== null && (
+                  <CategoryBadge
+                    category={categoryId}
+                    label={series.categoryName}
+                  />
+                )}
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <p className="text-base text-ot-background font-semibold">
+                  태그
+                </p>
+                <div className="flex flex-wrap gap-1">
+                  {categoryId !== null &&
+                    series.tagNameList.map((tag) => (
+                      <TagBadge key={tag} label={tag} category={categoryId} />
+                    ))}
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <p className="text-base text-ot-background font-semibold">
+                  공개여부
+                </p>
+                <AdminPublicBadge
+                  context="modal"
+                  isPublic={series.publicStatus === "PUBLIC"}
+                />
+              </div>
+            </section>
+
+            {/* 업로더 / 북마크 / 출연 */}
+            <section className="flex gap-6">
+              <div className="flex flex-col gap-1">
+                <p className="text-base text-ot-background font-semibold">
+                  업로더
+                </p>
+                <p className="text-sm text-ot-background">
+                  {series.uploaderNickname}
+                </p>
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <p className="text-base text-ot-background font-semibold">
+                  북마크
+                </p>
+                <p className="text-sm text-ot-background flex items-center gap-1">
+                  <Bookmark size={14} />
+                  {series.bookmarkCount.toLocaleString()}
+                </p>
+              </div>
+
+              {series.actors && (
+                <div className="flex flex-col gap-1">
+                  <p className="text-base text-ot-background font-semibold">
+                    출연
+                  </p>
+                  <p className="text-sm text-ot-background">{series.actors}</p>
+                </div>
+              )}
+            </section>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/entities/series/hooks/index.ts
+++ b/src/entities/series/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useInfiniteSeriesList } from "./useSeriesList";
 export { useSeriesDetail } from "./useSeriesDetail";
+export { useUploadSeries } from "./useUploadSeries";

--- a/src/entities/series/hooks/index.ts
+++ b/src/entities/series/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useInfiniteSeriesList } from "./useSeriesList";
+export { useSeriesDetail } from "./useSeriesDetail";

--- a/src/entities/series/hooks/index.ts
+++ b/src/entities/series/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useInfiniteSeriesList } from "./useSeriesList";
 export { useSeriesDetail } from "./useSeriesDetail";
 export { useUploadSeries } from "./useUploadSeries";
+export { useFixSeries } from "./useFixSeries";

--- a/src/entities/series/hooks/index.ts
+++ b/src/entities/series/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useInfiniteSeriesList } from "./useSeriesList";

--- a/src/entities/series/hooks/useFixSeries.ts
+++ b/src/entities/series/hooks/useFixSeries.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { FixSeriesRequest, fixSeriesApi } from "@entities/series/apis";
+
+export const useFixSeries = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: FixSeriesRequest) => fixSeriesApi(body),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["series", "list"] });
+      queryClient.invalidateQueries({
+        queryKey: ["series", "detail", variables.seriesId],
+      });
+    },
+  });
+};

--- a/src/entities/series/hooks/useSeriesDetail.ts
+++ b/src/entities/series/hooks/useSeriesDetail.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { getSeriesDetailApi } from "@entities/series/apis";
+
+export const useSeriesDetail = (mediaId: number | null) => {
+  return useQuery({
+    queryKey: ["series", "detail", mediaId],
+    queryFn: () => getSeriesDetailApi(mediaId!),
+    enabled: mediaId !== null,
+  });
+};

--- a/src/entities/series/hooks/useSeriesList.ts
+++ b/src/entities/series/hooks/useSeriesList.ts
@@ -1,0 +1,39 @@
+import { useInfiniteScroll } from "@/shared/hooks";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { SeriesListItem, getSeriesListApi } from "@entities/series/apis";
+
+interface UseInfiniteSeriesListParams {
+  size?: number;
+  searchWord?: string;
+}
+
+export const useInfiniteSeriesList = ({
+  size = 10,
+  searchWord,
+}: UseInfiniteSeriesListParams) => {
+  const query = useInfiniteQuery({
+    queryKey: ["series", "list", { size, searchWord }],
+    queryFn: ({ pageParam = 0 }) =>
+      getSeriesListApi({
+        page: pageParam as number,
+        size,
+        searchWord: searchWord || undefined,
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      const { currentPage, totalPage } = lastPage.pageInfo;
+      return currentPage + 1 < totalPage ? currentPage + 1 : undefined;
+    },
+  });
+
+  const { observerRef } = useInfiniteScroll({
+    hasNextPage: query.hasNextPage,
+    isFetchingNextPage: query.isFetchingNextPage,
+    fetchNextPage: query.fetchNextPage,
+  });
+
+  const seriesList: SeriesListItem[] =
+    query.data?.pages.flatMap((page) => page.dataList) ?? [];
+
+  return { ...query, seriesList, observerRef };
+};

--- a/src/entities/series/hooks/useUploadSeries.ts
+++ b/src/entities/series/hooks/useUploadSeries.ts
@@ -1,0 +1,12 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { UploadSeriesRequest, uploadSeriesApi } from "@entities/series/apis";
+
+export const useUploadSeries = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: UploadSeriesRequest) => uploadSeriesApi(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["series", "list"] });
+    },
+  });
+};

--- a/src/features/series-manage/components/AdminSeriesContents.tsx
+++ b/src/features/series-manage/components/AdminSeriesContents.tsx
@@ -174,8 +174,8 @@ export function AdminSeriesContents({ searchWord }: AdminSeriesContentsProps) {
           onUpdate={handleClose}
         />
       ) : (
-        selectedSeries && (
-          <AdminSeriesDetailModal series={selectedSeries} onClose={handleClose} />
+        hasSelectedMediaId && (
+          <AdminSeriesDetailModal mediaId={selectedMediaId!} onClose={handleClose} />
         )
       )}
     </>

--- a/src/features/series-manage/components/AdminSeriesContents.tsx
+++ b/src/features/series-manage/components/AdminSeriesContents.tsx
@@ -1,44 +1,57 @@
 "use client";
 
-import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
-import { Edit } from "lucide-react";
+import { Edit, Loader2 } from "lucide-react";
 import { AdminSeriesEditModal } from "@features/series-manage/components";
 import { CategoryBadge } from "@entities/category/components/CategoryBadge";
+import { useCategories } from "@entities/category/hooks";
 import { AdminSeriesDetailModal } from "@entities/series/components";
 import { TagBadge } from "@entities/tag/components/TagBagde";
 import { AdminPublicBadge } from "@shared/components";
-import { AdminSeries, mockAdminSeries } from "@shared/mocks/mockAdminSeries";
+import { useInfiniteSeriesList } from "@entities/series/hooks";
 
-export function AdminSeriesContents() {
-  const [data, setData] = useState<AdminSeries[]>(mockAdminSeries);
+interface AdminSeriesContentsProps {
+  searchWord?: string;
+}
+
+export function AdminSeriesContents({ searchWord }: AdminSeriesContentsProps) {
+  const { seriesList, observerRef, isLoading, isError, isFetchingNextPage } =
+    useInfiniteSeriesList({ searchWord });
+
+  const { data: categories } = useCategories();
+
+  const getCategoryId = (categoryName: string): number | null => {
+    return categories?.find((c) => c.categoryName === categoryName)?.categoryId ?? null;
+  };
+
   const router = useRouter();
   const searchParams = useSearchParams();
 
   const selectedId = searchParams.get("id");
   const action = searchParams.get("action");
 
-  const selectedSeries = selectedId
-    ? (data.find((s) => s.id === Number(selectedId)) ?? null)
+  const selectedMediaId = selectedId ? Number(selectedId) : null;
+  const hasSelectedMediaId =
+    selectedMediaId !== null && Number.isFinite(selectedMediaId);
+
+  const selectedSeries = hasSelectedMediaId
+    ? (seriesList.find((s) => s.mediaId === selectedMediaId) ?? null)
     : null;
 
-  const handleRowClick = (id: number) => {
-    router.push(`?id=${id}`, { scroll: false });
+  const handleRowClick = (mediaId: number) => {
+    router.push(`?id=${mediaId}`, { scroll: false });
   };
 
   const handleClose = () => {
     router.push("?", { scroll: false });
   };
 
-  const handleEditClick = (id: number) => {
-    router.push(`?id=${id}&action=edit`, { scroll: false });
+  const handleEditClick = (mediaId: number) => {
+    router.push(`?id=${mediaId}&action=edit`, { scroll: false });
   };
 
-  const handleUpdate = (updated: AdminSeries) => {
-    setData((prev) => prev.map((s) => (s.id === updated.id ? updated : s)));
-    handleClose();
-  };
+  if (isLoading) return <div>로딩 중...</div>;
+  if (isError) return <div>데이터를 불러오지 못했습니다.</div>;
 
   return (
     <>
@@ -65,82 +78,104 @@ export function AdminSeriesContents() {
           </thead>
 
           <tbody className="bg-ot-gray-700 divide-y divide-ot-gray-800">
-            {data.map((content) => (
-              <tr
-                key={content.id}
-                onClick={() => handleRowClick(content.id)}
-                className="hover:bg-ot-gray-800/30 transition-colors cursor-pointer"
-              >
-                <td className="py-3">
-                  <div className="relative aspect-5/7 max-w-12 w-full mx-auto">
-                    <Image
-                      src={content.posterUrl}
-                      alt={content.title}
-                      fill
-                      className="object-cover rounded-md"
-                    />
-                  </div>
-                </td>
-
-                <td className="py-3 text-center">
-                  <div className="flex flex-col font-semibold">
-                    <span>{content.title}</span>
-                  </div>
-                </td>
-
-                <td className="py-3 text-center">
-                  <div className="flex justify-center">
-                    <CategoryBadge category={content.category} />
-                  </div>
-                </td>
-
-                <td className="py-3 text-center">
-                  <div className="flex flex-wrap gap-1 justify-center">
-                    {content.tags.map((tag) => (
-                      <TagBadge
-                        key={tag}
-                        label={tag}
-                        category={content.category}
-                      />
-                    ))}
-                  </div>
-                </td>
-
-                <td className="py-3 text-center">
-                  <AdminPublicBadge
-                    isPublic={content.isPublic ? true : false}
-                  />
-                </td>
-
-                <td
-                  className="py-3 text-center"
-                  onClick={(e) => e.stopPropagation()}
+            {seriesList.map((content) => {
+              const categoryId = getCategoryId(content.categoryName);
+              return (
+                <tr
+                  key={content.mediaId}
+                  onClick={() => handleRowClick(content.mediaId)}
+                  className="hover:bg-ot-gray-800/30 transition-colors cursor-pointer"
                 >
-                  <button onClick={() => handleEditClick(content.id)}>
-                    <Edit
-                      size={20}
-                      className="hover:stroke-ot-gray-600 cursor-pointer"
+                  <td className="py-3">
+                    <div className="relative aspect-5/7 max-w-12 w-full mx-auto">
+                      {content.posterUrl ? (
+                      <div>{content.posterUrl} 예시</div>
+                    ) : (
+                      // TODO: 썸네일 넣어야 함
+                      // <Image
+                      //   src={content.posterUrl}
+                      //   alt={content.title}
+                      //   fill
+                      //   className="object-cover rounded-md"
+                      // />
+                      <div
+                        className="w-full h-full rounded-md bg-ot-gray-800"
+                        aria-label="썸네일 없음"
+                      />
+                    )}
+                    </div>
+                  </td>
+
+                  <td className="py-3 text-center">
+                    <div className="flex flex-col font-semibold">
+                      <span>{content.title}</span>
+                    </div>
+                  </td>
+
+                  <td className="py-3 text-center">
+                    <div className="flex justify-center">
+                      {categoryId !== null && (
+                        <CategoryBadge
+                          category={categoryId}
+                          label={content.categoryName}
+                        />
+                      )}
+                    </div>
+                  </td>
+
+                  <td className="py-3 text-center">
+                    <div className="flex flex-wrap gap-1 justify-center">
+                      {categoryId !== null &&
+                        content.tagNameList.map((tag) => (
+                          <TagBadge
+                            key={tag}
+                            label={tag}
+                            category={categoryId}
+                          />
+                        ))}
+                    </div>
+                  </td>
+
+                  <td className="py-3 text-center">
+                    <AdminPublicBadge
+                      isPublic={content.publicStatus === "PUBLIC"}
                     />
-                  </button>
-                </td>
-              </tr>
-            ))}
+                  </td>
+
+                  <td
+                    className="py-3 text-center"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <button onClick={() => handleEditClick(content.mediaId)}>
+                      <Edit
+                        size={20}
+                        className="hover:stroke-ot-gray-600 cursor-pointer"
+                      />
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
+
+        {/* 무한스크롤 감지 타겟 */}
+        <div ref={observerRef} className="py-4 flex justify-center">
+          {isFetchingNextPage && (
+            <Loader2 className="animate-spin text-ot-placeholder" size={20} />
+          )}
+        </div>
       </div>
 
-      {action === "edit" && selectedSeries ? (
+      {action === "edit" && hasSelectedMediaId ? (
         <AdminSeriesEditModal
           series={selectedSeries}
           onClose={handleClose}
-          onUpdate={handleUpdate}
+          onUpdate={handleClose}
         />
       ) : (
         selectedSeries && (
-          <AdminSeriesDetailModal
-            series={selectedSeries}
-            onClose={handleClose}
-          />
+          <AdminSeriesDetailModal series={selectedSeries} onClose={handleClose} />
         )
       )}
     </>

--- a/src/features/series-manage/components/AdminSeriesEditModal.tsx
+++ b/src/features/series-manage/components/AdminSeriesEditModal.tsx
@@ -173,7 +173,6 @@ export function AdminSeriesEditModal({
             className="relative w-218 bg-ot-text rounded-lg py-6 px-8 shadow-xl overflow-y-auto max-h-[90vh]"
             onClick={(e) => e.stopPropagation()}
           >
-            {/* 헤더 */}
             <div className="relative mb-8 text-ot-background">
               <p className="text-2xl font-bold">시리즈 수정</p>
               <button
@@ -204,7 +203,6 @@ export function AdminSeriesEditModal({
                 onChange={setDescription}
               />
 
-              {/* 카테고리 + 태그 */}
               <div className="grid grid-cols-2 gap-6">
                 <AdminCategoryDropdown
                   value={selectedCategory}
@@ -217,7 +215,6 @@ export function AdminSeriesEditModal({
                 />
               </div>
 
-              {/* 공개여부 */}
               <AdminPublicStatus isPublic={isPublic} onChange={setIsPublic} />
 
               <AdminTextInput
@@ -229,7 +226,6 @@ export function AdminSeriesEditModal({
 
               <AdminPosterUpload value={poster} onChange={setPoster} />
 
-              {/* 버튼 */}
               <div className="grid grid-cols-2 gap-4">
                 <CommonButton
                   type="button"

--- a/src/features/series-manage/components/AdminSeriesEditModal.tsx
+++ b/src/features/series-manage/components/AdminSeriesEditModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { X } from "lucide-react";
 import { AdminCategoryDropdown } from "@entities/category/components";
+import { useCategories } from "@entities/category/hooks";
 import { AdminTagDropdown } from "@entities/tag/components";
 import {
   AdminPosterUpload,
@@ -12,13 +13,13 @@ import {
   CommonButton,
   PosterState,
 } from "@shared/components";
-import { AdminSeries } from "@shared/mocks/mockAdminSeries";
-import { Category } from "@shared/types";
+import { SeriesListItem } from "@entities/series/apis";
+import { TAGS } from "@shared/types";
 
 interface AdminSeriesFixModalProps {
-  series: AdminSeries;
+  series: SeriesListItem | null;
   onClose: () => void;
-  onUpdate: (updated: AdminSeries) => void;
+  onUpdate: () => void;
 }
 
 export function AdminSeriesEditModal({
@@ -26,18 +27,37 @@ export function AdminSeriesEditModal({
   onClose,
   onUpdate,
 }: AdminSeriesFixModalProps) {
-  const [title, setTitle] = useState<string>(series.title);
-  const [description, setDescription] = useState<string>(series.description);
-  const [cast, setCast] = useState<string>(series.cast.join(", "));
-  const [isPublic, setIsPublic] = useState<boolean>(series.isPublic);
-  const [selectedCategory, setSelectedCategory] = useState<Category | null>(
-    series.category,
+  const { data: categories } = useCategories();
+
+  const [title, setTitle] = useState<string>(series?.title ?? "");
+  const [description, setDescription] = useState<string>("");
+  const [cast, setCast] = useState<string>("");
+  const [isPublic, setIsPublic] = useState<boolean>(
+    series?.publicStatus === "PUBLIC",
   );
-  const [selectedTags, setSelectedTags] = useState<string[]>(series.tags);
+  const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
+  const [selectedTags, setSelectedTags] = useState<number[]>([]);
   const [poster, setPoster] = useState<PosterState>({
     posterUrl: null,
     thumbnailUrl: null,
   });
+
+  useEffect(() => {
+    if (categories && series) {
+      const categoryId =
+        categories.find((c) => c.categoryName === series.categoryName)
+          ?.categoryId ?? null;
+      setSelectedCategory(categoryId);
+
+      if (categoryId !== null) {
+        const allTags = Object.values(TAGS).flat();
+        const tagIds = series.tagNameList
+          .map((name) => allTags.find((t) => t.name === name)?.tagId)
+          .filter((id): id is number => id !== undefined);
+        setSelectedTags(tagIds);
+      }
+    }
+  }, [categories, series]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -54,27 +74,15 @@ export function AdminSeriesEditModal({
     };
   }, []);
 
-  const handleCategoryChange = (category: Category | null) => {
+  const handleCategoryChange = (category: number | null) => {
     setSelectedCategory(category);
     setSelectedTags([]);
   };
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    onUpdate({
-      ...series,
-      title,
-      description,
-      category: selectedCategory ?? series.category,
-      tags: selectedTags,
-      isPublic,
-      cast: cast
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean),
-      posterUrl: poster.posterUrl ?? series.posterUrl,
-      thumbnailUrl: poster.thumbnailUrl ?? series.thumbnailUrl,
-    });
+    // TODO: 시리즈 수정 API 연동
+    onUpdate();
   };
 
   const [mounted, setMounted] = useState(false);

--- a/src/features/series-manage/components/AdminSeriesEditModal.tsx
+++ b/src/features/series-manage/components/AdminSeriesEditModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { X } from "lucide-react";
 import { AdminCategoryDropdown } from "@entities/category/components";
@@ -11,10 +11,14 @@ import {
   AdminPublicStatus,
   AdminTextInput,
   CommonButton,
+  ConfirmModal,
   PosterState,
 } from "@shared/components";
 import { SeriesListItem } from "@entities/series/apis";
+import { useFixSeries } from "@entities/series/hooks";
+import { useSeriesDetail } from "@entities/series/hooks";
 import { TAGS } from "@shared/types";
+import { uploadFileToS3 } from "@shared/lib";
 
 interface AdminSeriesFixModalProps {
   series: SeriesListItem | null;
@@ -28,6 +32,9 @@ export function AdminSeriesEditModal({
   onUpdate,
 }: AdminSeriesFixModalProps) {
   const { data: categories } = useCategories();
+  const { data: seriesDetail } = useSeriesDetail(series?.mediaId ?? null);
+
+  const { mutateAsync: fixSeries, isPending } = useFixSeries();
 
   const [title, setTitle] = useState<string>(series?.title ?? "");
   const [description, setDescription] = useState<string>("");
@@ -42,6 +49,18 @@ export function AdminSeriesEditModal({
     thumbnailUrl: null,
   });
 
+  const [fixError, setFixError] = useState<boolean>(false);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  // 시리즈 상세 정보로 폼 초기화
+  useEffect(() => {
+    if (seriesDetail) {
+      setDescription(seriesDetail.description);
+      setCast(seriesDetail.actors);
+    }
+  }, [seriesDetail]);
+
+  // 카테고리·태그 초기화
   useEffect(() => {
     if (categories && series) {
       const categoryId =
@@ -79,10 +98,60 @@ export function AdminSeriesEditModal({
     setSelectedTags([]);
   };
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleClose = () => {
+    if (isPending) return;
+    onClose();
+  };
+
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
-    // TODO: 시리즈 수정 API 연동
-    onUpdate();
+    if (!series || !selectedCategory || !seriesDetail) return;
+
+    try {
+      const { posterUploadUrl, thumbnailUploadUrl } = await fixSeries({
+        seriesId: seriesDetail.seriesId,
+        title,
+        description,
+        actors: cast,
+        publicStatus: isPublic ? "PUBLIC" : "PRIVATE",
+        categoryId: selectedCategory,
+        tagIdList: selectedTags,
+        ...(poster.posterFile && { posterFileName: poster.posterFile.name }),
+        ...(poster.thumbnailFile && {
+          thumbnailFileName: poster.thumbnailFile.name,
+        }),
+      });
+
+      // 새 이미지가 있는 경우 S3에 업로드
+      const s3Uploads: Promise<void>[] = [];
+      if (posterUploadUrl && poster.posterFile) {
+        s3Uploads.push(uploadFileToS3(posterUploadUrl, poster.posterFile));
+      }
+      if (thumbnailUploadUrl && poster.thumbnailFile) {
+        s3Uploads.push(
+          uploadFileToS3(thumbnailUploadUrl, poster.thumbnailFile),
+        );
+      }
+      if (s3Uploads.length > 0) {
+        await Promise.all(s3Uploads);
+      }
+
+      onUpdate();
+    } catch (error) {
+      console.error("수정 실패:", error);
+      setFixError(true);
+    }
+  };
+
+  const handleRetry = () => {
+    setFixError(false);
+    requestAnimationFrame(() => {
+      formRef.current?.requestSubmit();
+    });
+  };
+
+  const handleErrorClose = () => {
+    setFixError(false);
   };
 
   const [mounted, setMounted] = useState(false);
@@ -93,87 +162,107 @@ export function AdminSeriesEditModal({
 
   if (!mounted) return null;
 
-  return createPortal(
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={onClose}
-    >
-      <div
-        className="relative w-218 bg-ot-text rounded-lg py-6 px-8 shadow-xl overflow-y-auto max-h-[90vh]"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* 헤더 */}
-        <div className="relative mb-8 text-ot-background">
-          <p className="text-2xl font-bold">시리즈 수정</p>
-          <button
-            onClick={onClose}
-            className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"
-          >
-            <X size={22} />
-          </button>
-        </div>
-
-        <form
-          className="grid gap-y-6 text-ot-background"
-          onSubmit={handleSubmit}
+  return (
+    <>
+      {createPortal(
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={handleClose}
         >
-          <AdminTextInput
-            label="제목"
-            placeholder="콘텐츠 제목을 입력하세요"
-            value={title}
-            onChange={setTitle}
-          />
+          <div
+            className="relative w-218 bg-ot-text rounded-lg py-6 px-8 shadow-xl overflow-y-auto max-h-[90vh]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* 헤더 */}
+            <div className="relative mb-8 text-ot-background">
+              <p className="text-2xl font-bold">시리즈 수정</p>
+              <button
+                onClick={handleClose}
+                className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"
+              >
+                <X size={22} />
+              </button>
+            </div>
 
-          <AdminTextInput
-            label="설명"
-            placeholder="콘텐츠 설명을 입력하세요"
-            multiline
-            value={description}
-            onChange={setDescription}
-          />
-
-          {/* 카테고리 + 태그 */}
-          <div className="grid grid-cols-2 gap-6">
-            <AdminCategoryDropdown
-              value={selectedCategory}
-              onChange={handleCategoryChange}
-            />
-            <AdminTagDropdown
-              category={selectedCategory}
-              value={selectedTags}
-              onChange={setSelectedTags}
-            />
-          </div>
-
-          {/* 공개여부 */}
-          <AdminPublicStatus isPublic={isPublic} onChange={setIsPublic} />
-
-          <AdminTextInput
-            label="출연"
-            placeholder="출연진은 쉼표(,)로 구분해 입력해 주세요 (예: 임지연, 송혜교, 이도현 · 최대 4인)"
-            value={cast}
-            onChange={setCast}
-          />
-
-          <AdminPosterUpload value={poster} onChange={setPoster} />
-
-          {/* 버튼 */}
-          <div className="grid grid-cols-2 gap-4">
-            <CommonButton
-              type="button"
-              onClick={onClose}
-              className="py-3 font-semibold"
-              variant="outline"
+            <form
+              ref={formRef}
+              className="grid gap-y-6 text-ot-background"
+              onSubmit={handleSubmit}
             >
-              취소
-            </CommonButton>
-            <CommonButton type="submit" className="py-3 font-semibold">
-              수정 완료
-            </CommonButton>
+              <AdminTextInput
+                label="제목"
+                placeholder="콘텐츠 제목을 입력하세요"
+                value={title}
+                onChange={setTitle}
+              />
+
+              <AdminTextInput
+                label="설명"
+                placeholder="콘텐츠 설명을 입력하세요"
+                multiline
+                value={description}
+                onChange={setDescription}
+              />
+
+              {/* 카테고리 + 태그 */}
+              <div className="grid grid-cols-2 gap-6">
+                <AdminCategoryDropdown
+                  value={selectedCategory}
+                  onChange={handleCategoryChange}
+                />
+                <AdminTagDropdown
+                  category={selectedCategory}
+                  value={selectedTags}
+                  onChange={setSelectedTags}
+                />
+              </div>
+
+              {/* 공개여부 */}
+              <AdminPublicStatus isPublic={isPublic} onChange={setIsPublic} />
+
+              <AdminTextInput
+                label="출연"
+                placeholder="출연진은 쉼표(,)로 구분해 입력해 주세요 (예: 임지연, 송혜교, 이도현 · 최대 4인)"
+                value={cast}
+                onChange={setCast}
+              />
+
+              <AdminPosterUpload value={poster} onChange={setPoster} />
+
+              {/* 버튼 */}
+              <div className="grid grid-cols-2 gap-4">
+                <CommonButton
+                  type="button"
+                  onClick={handleClose}
+                  className="py-3 font-semibold"
+                  variant="outline"
+                  disabled={isPending}
+                >
+                  취소
+                </CommonButton>
+                <CommonButton
+                  type="submit"
+                  className="py-3 font-semibold"
+                  disabled={isPending}
+                >
+                  {isPending ? "수정 중..." : "수정 완료"}
+                </CommonButton>
+              </div>
+            </form>
           </div>
-        </form>
-      </div>
-    </div>,
-    document.body,
+        </div>,
+        document.body,
+      )}
+
+      <ConfirmModal
+        isOpen={fixError}
+        message={"수정에 실패했습니다.\n다시 시도하시겠습니까?"}
+        confirmText="재시도"
+        cancelText="취소"
+        onConfirm={handleRetry}
+        onClose={handleErrorClose}
+        disabled={isPending}
+      />
+    </>
   );
 }

--- a/src/features/series-manage/components/AdminSeriesUploadModal.tsx
+++ b/src/features/series-manage/components/AdminSeriesUploadModal.tsx
@@ -1,18 +1,20 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { X } from "lucide-react";
 import { AdminCategoryDropdown } from "@entities/category/components";
+import { useUploadSeries } from "@entities/series/hooks";
 import { AdminTagDropdown } from "@entities/tag/components";
 import {
   AdminPosterUpload,
   AdminPublicStatus,
   AdminTextInput,
   CommonButton,
+  ConfirmModal,
   PosterState,
 } from "@shared/components";
-import { Category } from "@shared/types";
+import { uploadFileToS3 } from "@shared/lib";
 
 interface AdminSeriesUploadModalProps {
   open: boolean;
@@ -23,20 +25,32 @@ export function AdminSeriesUploadModal({
   open,
   onClose,
 }: AdminSeriesUploadModalProps) {
+  const { mutateAsync: uploadSeries, isPending } = useUploadSeries();
+
   const [mounted, setMounted] = useState<boolean>(false);
 
   const [title, setTitle] = useState<string>("");
   const [description, setDescription] = useState<string>("");
   const [cast, setCast] = useState<string>("");
   const [isPublic, setIsPublic] = useState<boolean>(false);
-  const [selectedCategory, setSelectedCategory] = useState<Category | null>(
-    null,
-  );
-  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
+  const [selectedTags, setSelectedTags] = useState<number[]>([]);
   const [poster, setPoster] = useState<PosterState>({
     posterUrl: null,
     thumbnailUrl: null,
   });
+
+  const [uploadError, setUploadError] = useState<boolean>(false);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const isFormValid =
+    !!title.trim() &&
+    !!description.trim() &&
+    !!cast.trim() &&
+    !!selectedCategory &&
+    selectedTags.length > 0 &&
+    !!poster.posterFile &&
+    !!poster.thumbnailFile;
 
   useEffect(() => {
     setMounted(true);
@@ -58,99 +72,155 @@ export function AdminSeriesUploadModal({
     };
   }, [open]);
 
-  const handleCategoryChange = (category: Category | null) => {
+  const handleCategoryChange = (category: number | null) => {
     setSelectedCategory(category);
     setSelectedTags([]);
   };
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleClose = () => {
+    if (isPending) return;
+    onClose();
+  };
+
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log("시리즈 등록 처리 로직");
+
+    try {
+      // 1. 메타데이터 전송 → Presigned URL 수신
+      const { posterUploadUrl, thumbnailUploadUrl } = await uploadSeries({
+        title,
+        description,
+        actors: cast,
+        publicStatus: isPublic ? "PUBLIC" : "PRIVATE",
+        categoryId: selectedCategory!,
+        tagIdList: selectedTags,
+        posterFileName: poster.posterFile!.name,
+        thumbnailFileName: poster.thumbnailFile!.name,
+      });
+
+      // 2. S3 직접 업로드 (병렬)
+      await Promise.all([
+        uploadFileToS3(posterUploadUrl, poster.posterFile!),
+        uploadFileToS3(thumbnailUploadUrl, poster.thumbnailFile!),
+      ]);
+
+      onClose();
+    } catch (error) {
+      console.error("업로드 실패:", error);
+      setUploadError(true);
+    }
+  };
+
+  const handleRetry = () => {
+    setUploadError(false);
+    requestAnimationFrame(() => {
+      formRef.current?.requestSubmit();
+    });
+  };
+
+  const handleErrorClose = () => {
+    setUploadError(false);
   };
 
   if (!mounted || !open) return null;
 
-  return createPortal(
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={onClose}
-    >
-      <div
-        className="relative w-218 bg-ot-text rounded-lg py-6 px-8 shadow-xl overflow-y-auto max-h-[90vh]"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* 헤더 */}
-        <div className="relative mb-8 text-ot-background">
-          <p className="text-2xl font-bold">시리즈 등록</p>
-          <button
-            onClick={onClose}
-            className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"
-          >
-            <X size={22} />
-          </button>
-        </div>
-
-        <form
-          className="grid gap-y-6 text-ot-background"
-          onSubmit={handleSubmit}
+  return (
+    <>
+      {createPortal(
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={handleClose}
         >
-          <AdminTextInput
-            label="제목"
-            placeholder="콘텐츠 제목을 입력하세요"
-            value={title}
-            onChange={setTitle}
-          />
+          <div
+            className="relative w-218 bg-ot-text rounded-lg py-6 px-8 shadow-xl overflow-y-auto max-h-[90vh]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="relative mb-8 text-ot-background">
+              <p className="text-2xl font-bold">시리즈 등록</p>
+              <button
+                onClick={handleClose}
+                className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"
+              >
+                <X size={22} />
+              </button>
+            </div>
 
-          <AdminTextInput
-            label="설명"
-            placeholder="콘텐츠 설명을 입력하세요"
-            multiline
-            value={description}
-            onChange={setDescription}
-          />
-
-          {/* 카테고리 + 태그 */}
-          <div className="grid grid-cols-2 gap-6">
-            <AdminCategoryDropdown
-              value={selectedCategory}
-              onChange={handleCategoryChange}
-            />
-            <AdminTagDropdown
-              category={selectedCategory}
-              value={selectedTags}
-              onChange={setSelectedTags}
-            />
-          </div>
-
-          {/* 공개여부 */}
-          <AdminPublicStatus isPublic={isPublic} onChange={setIsPublic} />
-
-          <AdminTextInput
-            label="출연"
-            placeholder="출연진은 쉼표(,)로 구분해 입력해 주세요 (예: 임지연, 송혜교, 이도현 · 최대 4인)"
-            value={cast}
-            onChange={setCast}
-          />
-
-          <AdminPosterUpload value={poster} onChange={setPoster} />
-
-          {/* 버튼 */}
-          <div className="grid grid-cols-2 gap-4">
-            <CommonButton
-              type="button"
-              onClick={onClose}
-              className="py-3 font-semibold"
-              variant="outline"
+            <form
+              ref={formRef}
+              className="grid gap-y-6 text-ot-background"
+              onSubmit={handleSubmit}
             >
-              취소
-            </CommonButton>
-            <CommonButton type="submit" className="py-3 font-semibold">
-              업로드 시작
-            </CommonButton>
+              <AdminTextInput
+                label="제목"
+                placeholder="콘텐츠 제목을 입력하세요"
+                value={title}
+                onChange={setTitle}
+              />
+
+              <AdminTextInput
+                label="설명"
+                placeholder="콘텐츠 설명을 입력하세요"
+                multiline
+                value={description}
+                onChange={setDescription}
+              />
+
+              <div className="grid grid-cols-2 gap-6">
+                <AdminCategoryDropdown
+                  value={selectedCategory}
+                  onChange={handleCategoryChange}
+                />
+                <AdminTagDropdown
+                  category={selectedCategory}
+                  value={selectedTags}
+                  onChange={setSelectedTags}
+                />
+              </div>
+
+              <AdminPublicStatus isPublic={isPublic} onChange={setIsPublic} />
+
+              <AdminTextInput
+                label="출연"
+                placeholder="출연진은 쉼표(,)로 구분해 입력해 주세요 (예: 임지연, 송혜교, 이도현 · 최대 4인)"
+                value={cast}
+                onChange={setCast}
+              />
+
+              <AdminPosterUpload value={poster} onChange={setPoster} />
+
+              <div className="grid grid-cols-2 gap-4">
+                <CommonButton
+                  type="button"
+                  onClick={handleClose}
+                  className="py-3 font-semibold"
+                  variant="outline"
+                  disabled={isPending}
+                >
+                  취소
+                </CommonButton>
+                <CommonButton
+                  type="submit"
+                  className="py-3 font-semibold"
+                  disabled={isPending || !isFormValid}
+                >
+                  {isPending ? "업로드 중..." : "업로드 시작"}
+                </CommonButton>
+              </div>
+            </form>
           </div>
-        </form>
-      </div>
-    </div>,
-    document.body,
+        </div>,
+        document.body,
+      )}
+
+      <ConfirmModal
+        isOpen={uploadError}
+        message={"업로드에 실패했습니다.\n다시 시도하시겠습니까?"}
+        confirmText="재시도"
+        cancelText="취소"
+        onConfirm={handleRetry}
+        onClose={handleErrorClose}
+        disabled={isPending}
+      />
+    </>
   );
 }

--- a/src/features/series-manage/components/AdminSeriesUploadModal.tsx
+++ b/src/features/series-manage/components/AdminSeriesUploadModal.tsx
@@ -14,6 +14,7 @@ import {
   ConfirmModal,
   PosterState,
 } from "@shared/components";
+import { useIsMounted } from "@shared/hooks";
 import { uploadFileToS3 } from "@shared/lib";
 
 interface AdminSeriesUploadModalProps {
@@ -25,22 +26,35 @@ export function AdminSeriesUploadModal({
   open,
   onClose,
 }: AdminSeriesUploadModalProps) {
+  const mounted = useIsMounted();
+
+  useEffect(() => {
+    document.body.style.overflow = open ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  if (!mounted || !open) return null;
+
+  return <ModalInner onClose={onClose} />;
+}
+
+function ModalInner({ onClose }: { onClose: () => void }) {
   const { mutateAsync: uploadSeries, isPending } = useUploadSeries();
 
-  const [mounted, setMounted] = useState<boolean>(false);
-
-  const [title, setTitle] = useState<string>("");
-  const [description, setDescription] = useState<string>("");
-  const [cast, setCast] = useState<string>("");
-  const [isPublic, setIsPublic] = useState<boolean>(false);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [cast, setCast] = useState("");
+  const [isPublic, setIsPublic] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
   const [poster, setPoster] = useState<PosterState>({
     posterUrl: null,
     thumbnailUrl: null,
   });
+  const [uploadError, setUploadError] = useState(false);
 
-  const [uploadError, setUploadError] = useState<boolean>(false);
   const formRef = useRef<HTMLFormElement>(null);
 
   const isFormValid =
@@ -53,34 +67,12 @@ export function AdminSeriesUploadModal({
     !!poster.thumbnailFile;
 
   useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  useEffect(() => {
-    if (!open) return;
-
-    setTitle("");
-    setDescription("");
-    setCast("");
-    setIsPublic(false);
-    setSelectedCategory(null);
-    setSelectedTags([]);
-    setPoster({ posterUrl: null, thumbnailUrl: null });
-    setUploadError(false);
-
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [open, onClose]);
-
-  useEffect(() => {
-    document.body.style.overflow = open ? "hidden" : "";
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [open]);
+  }, [onClose]);
 
   const handleCategoryChange = (category: number | null) => {
     setSelectedCategory(category);
@@ -127,12 +119,6 @@ export function AdminSeriesUploadModal({
       formRef.current?.requestSubmit();
     });
   };
-
-  const handleErrorClose = () => {
-    setUploadError(false);
-  };
-
-  if (!mounted || !open) return null;
 
   return (
     <>
@@ -228,7 +214,7 @@ export function AdminSeriesUploadModal({
         confirmText="재시도"
         cancelText="취소"
         onConfirm={handleRetry}
-        onClose={handleErrorClose}
+        onClose={() => setUploadError(false)}
         disabled={isPending}
       />
     </>

--- a/src/features/series-manage/components/AdminSeriesUploadModal.tsx
+++ b/src/features/series-manage/components/AdminSeriesUploadModal.tsx
@@ -58,6 +58,16 @@ export function AdminSeriesUploadModal({
 
   useEffect(() => {
     if (!open) return;
+
+    setTitle("");
+    setDescription("");
+    setCast("");
+    setIsPublic(false);
+    setSelectedCategory(null);
+    setSelectedTags([]);
+    setPoster({ posterUrl: null, thumbnailUrl: null });
+    setUploadError(false);
+
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };

--- a/src/features/video-contents-manage/components/AdminVideoContentsUploadModal.tsx
+++ b/src/features/video-contents-manage/components/AdminVideoContentsUploadModal.tsx
@@ -19,6 +19,7 @@ import {
   PosterState,
 } from "@shared/components";
 import { uploadFileToS3 } from "@shared/lib";
+import { useIsMounted } from "@shared/hooks";
 import { ContentType, VideoFileMeta } from "@shared/types";
 
 interface AdminUploadModalProps {
@@ -40,15 +41,27 @@ export function AdminVideoContentsUploadModal({
   open,
   onClose,
 }: AdminUploadModalProps) {
+  const mounted = useIsMounted();
+
+  useEffect(() => {
+    document.body.style.overflow = open ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  if (!mounted || !open) return null;
+
+  return <ModalInner onClose={onClose} />;
+}
+
+function ModalInner({ onClose }: { onClose: () => void }) {
   const { mutateAsync: uploadVideo, isPending } = useUploadVideoContents();
 
-  const [mounted, setMounted] = useState<boolean>(false);
-
-  const [title, setTitle] = useState<string>("");
-  const [description, setDescription] = useState<string>("");
-  const [cast, setCast] = useState<string>("");
-  const [isPublic, setIsPublic] = useState<boolean>(false);
-
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [cast, setCast] = useState("");
+  const [isPublic, setIsPublic] = useState(false);
   const [videoFile, setVideoFile] = useState<VideoFileMeta | null>(null);
   const [selectedSeries, setSelectedSeries] = useState<string | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
@@ -58,8 +71,7 @@ export function AdminVideoContentsUploadModal({
     thumbnailUrl: null,
   });
   const [contentType, setContentType] = useState<ContentType>("단편");
-
-  const [uploadError, setUploadError] = useState<boolean>(false);
+  const [uploadError, setUploadError] = useState(false);
 
   const formRef = useRef<HTMLFormElement>(null);
 
@@ -75,24 +87,12 @@ export function AdminVideoContentsUploadModal({
     (contentType !== "시리즈" || !!selectedSeries);
 
   useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  useEffect(() => {
-    if (!open) return;
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [open, onClose]);
-
-  useEffect(() => {
-    document.body.style.overflow = open ? "hidden" : "";
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [open]);
+  }, [onClose]);
 
   const handleCategoryChange = (category: number | null) => {
     setSelectedCategory(category);
@@ -160,12 +160,6 @@ export function AdminVideoContentsUploadModal({
       formRef.current?.requestSubmit();
     });
   };
-
-  const handleErrorClose = () => {
-    setUploadError(false);
-  };
-
-  if (!mounted || !open) return null;
 
   return (
     <>
@@ -280,7 +274,7 @@ export function AdminVideoContentsUploadModal({
         confirmText="재시도"
         cancelText="취소"
         onConfirm={handleRetry}
-        onClose={handleErrorClose}
+        onClose={() => setUploadError(false)}
         disabled={isPending}
       />
     </>

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useOutsideClick } from "./useOutsideClick";
 export { useInfiniteScroll } from "./useInfiniteScroll";
+export { useIsMounted } from "./useIsMounted";

--- a/src/shared/hooks/useIsMounted.ts
+++ b/src/shared/hooks/useIsMounted.ts
@@ -1,0 +1,9 @@
+import { useSyncExternalStore } from "react";
+
+const subscribe = (_onStoreChange: () => void): (() => void) => () => {};
+const getSnapshot = (): boolean => true;
+const getServerSnapshot = (): boolean => false;
+
+export function useIsMounted(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
## 📝 작업 내용

> 시리즈 관리 페이지에서 필요한 API를 연동했습니다. 
<img width="1216" height="276" alt="image" src="https://github.com/user-attachments/assets/686a2c8e-c51b-4c18-bc75-7a237f35ff26" />

- [x] 시리즈 목록 LIst 조회 API
- [x] 시리즈 상세조회 API
- [x] 시리즈 메타데이터 업로드 API
- [x] 시리즈 수정 API

## 📷 구현 영상 
- 시리즈 수정 영상

https://github.com/user-attachments/assets/eb907b2f-27bb-44dd-b50e-5905a5324619

- 시리즈 업로드 영상


https://github.com/user-attachments/assets/8a6cde09-21e8-4256-96cc-5fce4f5115ee




## 🖥️ 주요 코드 설명

`AdminSeriesEditModal`

- AdminSeriesEditModal에서 수정 API를 진행하는 과정에서 트러블이 있었습니다.
- 현재, 시리즈 List API를 조회하면 `mediaId` 값이 ResponseBody에 담겨져 오고 있습니다.
- 그리고 그 mediaId값을 가지고 상세조회 API를 진행할 때, parameter로 전달하고 Response로 `SeriesId`를 받게됩니다. 
- 하지만 현재, URL에서 쿼리로는 mediaId가 나와있어, 수정 API parameter인 SeriesId를 따로 불러와야 하는 상황입니다!
- 따라서, `seriesDetail.seriesId`로 하여 해결하였습니다!

```ts
try {
      const { posterUploadUrl, thumbnailUploadUrl } = await fixSeries({
        seriesId: seriesDetail.seriesId,
        title,
        description,
        actors: cast,
        publicStatus: isPublic ? "PUBLIC" : "PRIVATE",
        categoryId: selectedCategory,
        tagIdList: selectedTags,
```

## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #17 

## 💬 리뷰 요구사항

- Vercel관련해서 배포를 진행할려고 했는데 파일중 `AdminOriginalContentsDropdown` 이 파일이 없다고합니다!
- 확인 결과, 주희님께서 콘텐츠 수정 이후 커밋 예정이라고 하셔서 추후에 배포 진행하겠습니다!  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시리즈 목록 조회(검색·페이징·무한스크롤), 상세조회, 업로드 및 수정(편집) 기능 추가
  * 업로드/수정 시 포스터·썸네일용 업로드 URL 제공 및 파일 업로드 워크플로우 도입
  * 관련 모달(업로드/편집/상세) UX 개선 및 오류 재시도 흐름 추가

* **리팩토링**
  * 시리즈 관리 UI를 데이터 기반으로 전환하고 로딩/오류 상태 처리 향상
  * 공용 훅(목록/상세/업로드/수정/마운트 체크) 재구성 및 노출 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->