### PR TITLE
[OT-192] [FEAT]: 콘텐츠 수정 API 연동, 콘텐츠 업로드 최종 구현 완료

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,18 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   reactCompiler: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "oplust-content-0370aace.s3.ap-northeast-2.amazonaws.com",
+      },
+      {
+        protocol: "https",
+        hostname: "cdn.openthetaste.cloud",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/entities/category/constants/categoryColor.ts
+++ b/src/entities/category/constants/categoryColor.ts
@@ -3,7 +3,6 @@ export const CATEGORY_CONFIG_COLOR: Record<number, { className: string }> = {
   2: { className: "bg-ot-red text-ot-text" },
   3: { className: "bg-ot-orange text-ot-text" },
   4: { className: "bg-ot-mint text-ot-text" },
-  // FIXME: 추후 카테고리 추가되면 아래 항목 주석 해제
-  // 5: { className: "bg-ot-green text-ot-text" },
-  // 6: { className: "bg-ot-blue text-ot-text" },
+  5: { className: "bg-ot-green text-ot-text" },
+  6: { className: "bg-ot-blue text-ot-text" },
 };

--- a/src/entities/series/components/AdminSeriesDropdown.tsx
+++ b/src/entities/series/components/AdminSeriesDropdown.tsx
@@ -1,38 +1,43 @@
 "use client";
-
+// 콘텐츠 모달 내 시리즈 드롭다운
 import { useRef, useState } from "react";
 import { ChevronDown, Search } from "lucide-react";
+import { SeriesListItem } from "@entities/series/apis";
+import { useInfiniteSeriesList } from "@entities/series/hooks";
 import { useOutsideClick } from "@shared/hooks";
 import { cn } from "@shared/utils";
 
 export interface AdminSeriesDropdownProps {
-  seriesList: string[];
-  value: string | null;
-  onChange: (series: string | null) => void;
+  value: number | null;
+  onChange: (seriesId: number | null, item: SeriesListItem | null) => void;
   disabled?: boolean;
 }
 
 export function AdminSeriesDropdown({
-  seriesList,
   value,
   onChange,
   disabled = false,
 }: AdminSeriesDropdownProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [search, setSearch] = useState<string>("");
+  const [searchWord, setSearchWord] = useState<string>("");
   const dropdownRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  const filtered = seriesList.filter((s) => s.includes(search));
+  // FIXME: 추후 시리즈 제목 조회 api로 연동 필요 (백엔드 수정 완료 시)
+  const { seriesList, observerRef, isFetchingNextPage } = useInfiniteSeriesList(
+    { searchWord },
+  );
 
   useOutsideClick(dropdownRef, () => setIsOpen(false), isOpen);
 
-  const handleSelect = (series: string) => {
-    onChange(series === "시리즈 없음" ? null : series);
+  const handleSelect = (item: SeriesListItem | null) => {
+    onChange(item ? item.mediaId : null, item);
     setIsOpen(false);
-    setSearch("");
+    setSearchWord("");
     if (searchInputRef.current) searchInputRef.current.value = "";
   };
+
+  const selectedTitle = seriesList.find((s) => s.mediaId === value)?.title;
 
   return (
     <div>
@@ -44,7 +49,7 @@ export function AdminSeriesDropdown({
           disabled={disabled}
           onClick={() => {
             setIsOpen((prev) => !prev);
-            setSearch("");
+            setSearchWord("");
           }}
           className={cn(
             "w-full flex items-center justify-between border rounded-lg py-3 px-4 text-sm text-left transition-colors",
@@ -56,7 +61,7 @@ export function AdminSeriesDropdown({
           <span
             className={cn(value ? "text-ot-background" : "text-ot-gray-600")}
           >
-            {value ?? "시리즈 선택"}
+            {selectedTitle ?? "시리즈 선택"}
           </span>
 
           <ChevronDown
@@ -78,7 +83,7 @@ export function AdminSeriesDropdown({
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
                     e.preventDefault();
-                    setSearch(searchInputRef.current?.value ?? "");
+                    setSearchWord(searchInputRef.current?.value ?? "");
                   }
                 }}
                 placeholder="시리즈 검색"
@@ -88,33 +93,48 @@ export function AdminSeriesDropdown({
             </div>
 
             <div className="max-h-48 overflow-y-auto">
-              {filtered.length > 0 ? (
-                filtered.map((series) => {
-                  const isSelected =
-                    value === series ||
-                    (series === "시리즈 없음" && value === null);
+              <button
+                type="button"
+                onClick={() => handleSelect(null)}
+                className={cn(
+                  "w-full text-left px-4 py-3 text-sm transition-colors cursor-pointer",
+                  value === null
+                    ? "bg-ot-primary-gradient text-ot-text"
+                    : "text-ot-background hover:bg-ot-gray-200",
+                )}
+              >
+                시리즈 없음
+              </button>
 
-                  return (
-                    <button
-                      type="button"
-                      key={series}
-                      onClick={() => handleSelect(series)}
-                      className={cn(
-                        "w-full text-left px-4 py-3 text-sm transition-colors cursor-pointer",
-                        isSelected
-                          ? "bg-ot-primary-gradient text-ot-text"
-                          : "text-ot-background hover:bg-ot-gray-200",
-                      )}
-                    >
-                      {series}
-                    </button>
-                  );
-                })
+              {seriesList.length > 0 ? (
+                seriesList.map((series) => (
+                  <button
+                    type="button"
+                    key={series.mediaId}
+                    onClick={() => handleSelect(series)}
+                    className={cn(
+                      "w-full text-left px-4 py-3 text-sm transition-colors cursor-pointer",
+                      value === series.mediaId
+                        ? "bg-ot-primary-gradient text-ot-text"
+                        : "text-ot-background hover:bg-ot-gray-200",
+                    )}
+                  >
+                    {series.title}
+                  </button>
+                ))
               ) : (
                 <p className="px-4 py-3 text-sm text-ot-gray-600">
                   검색 결과가 없습니다
                 </p>
               )}
+
+              <div ref={observerRef} className="py-1">
+                {isFetchingNextPage && (
+                  <p className="text-center text-xs text-ot-gray-600 py-1">
+                    불러오는 중...
+                  </p>
+                )}
+              </div>
             </div>
           </div>
         )}

--- a/src/entities/statistics/hooks/useTagsByCategory.ts
+++ b/src/entities/statistics/hooks/useTagsByCategory.ts
@@ -2,9 +2,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { getTagsByCategory } from "@entities/statistics/apis";
 
-export const useTagsByCategory = (categoryId: number) => {
+export const useTagsByCategory = (categoryId: number | null) => {
   return useQuery({
     queryKey: ["tagsByCategory", categoryId],
-    queryFn: () => getTagsByCategory(categoryId),
+    queryFn: () => getTagsByCategory(categoryId!),
+    enabled: categoryId !== null,
   });
 };

--- a/src/entities/tag/components/AdminTagDropdown.tsx
+++ b/src/entities/tag/components/AdminTagDropdown.tsx
@@ -2,9 +2,9 @@
 
 import { useRef, useState } from "react";
 import { ChevronDown } from "lucide-react";
+import { useTagsByCategory } from "@entities/statistics/hooks";
 import { TagBadge } from "@entities/tag/components";
 import { useOutsideClick } from "@shared/hooks";
-import { TAGS } from "@shared/types";
 import { cn } from "@shared/utils";
 
 export interface AdminTagDropdownProps {
@@ -18,12 +18,13 @@ export function AdminTagDropdown({
   value,
   onChange,
 }: AdminTagDropdownProps) {
+  const { data: tagList, isPending, isError } = useTagsByCategory(category);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   useOutsideClick(dropdownRef, () => setIsOpen(false), isOpen);
 
-  const tags = category ? TAGS[category] : [];
+  const tags = tagList ?? [];
 
   const handleToggle = (tagId: number) => {
     onChange(
@@ -87,29 +88,37 @@ export function AdminTagDropdown({
           </div>
         )}
 
-        {/* FIXME: tag  */}
         {isOpen && category && (
           <div className="absolute top-full left-0 right-0 z-20 mt-2 bg-ot-text rounded-lg shadow-lg overflow-hidden border border-ot-gray-600">
             <div className="max-h-48 overflow-y-auto">
-              {tags.map((tag) => {
-                const isSelected = value.includes(tag.tagId);
-
-                return (
-                  <button
-                    type="button"
-                    key={tag.tagId}
-                    onClick={() => handleToggle(tag.tagId)}
-                    className={cn(
-                      "w-full text-left px-4 py-3 text-sm transition-colors cursor-pointer",
-                      isSelected
-                        ? "bg-ot-primary-gradient text-ot-text"
-                        : "text-ot-background hover:bg-ot-gray-200",
-                    )}
-                  >
-                    {tag.name}
-                  </button>
-                );
-              })}
+              {isPending ? (
+                <p className="px-4 py-3 text-sm text-ot-gray-600">
+                  불러오는 중...
+                </p>
+              ) : isError ? (
+                <p className="px-4 py-3 text-sm text-ot-gray-600">
+                  태그를 불러오지 못했습니다.
+                </p>
+              ) : (
+                tags.map((tag) => {
+                  const isSelected = value.includes(tag.tagId);
+                  return (
+                    <button
+                      type="button"
+                      key={tag.tagId}
+                      onClick={() => handleToggle(tag.tagId)}
+                      className={cn(
+                        "w-full text-left px-4 py-3 text-sm transition-colors cursor-pointer",
+                        isSelected
+                          ? "bg-ot-primary-gradient text-ot-text"
+                          : "text-ot-background hover:bg-ot-gray-200",
+                      )}
+                    >
+                      {tag.name}
+                    </button>
+                  );
+                })
+              )}
             </div>
           </div>
         )}

--- a/src/entities/tag/constants/tagColor.ts
+++ b/src/entities/tag/constants/tagColor.ts
@@ -3,7 +3,6 @@ export const CATEGORY_DOT_COLOR: Record<number, string> = {
   2: "bg-ot-red",
   3: "bg-ot-orange",
   4: "bg-ot-mint",
-  // FIXME: 카테고리 추가되면 여기에 추가하기
-  // 뉴스: "bg-ot-green",
-  // 스포츠: "bg-ot-blue",
+  5: "bg-ot-green",
+  6: "bg-ot-blue",
 };

--- a/src/entities/video-contents/apis/getVideoContentsApi.ts
+++ b/src/entities/video-contents/apis/getVideoContentsApi.ts
@@ -37,7 +37,7 @@ export const getContentListApi = async (params: GetContentListParams) => {
 };
 
 export interface ContentDetailResponse {
-  contentId: number;
+  contentsId: number;
   posterUrl: string;
   thumbnailUrl: string;
   title: string;

--- a/src/entities/video-contents/components/AdminVideoContentsDetailModal.tsx
+++ b/src/entities/video-contents/components/AdminVideoContentsDetailModal.tsx
@@ -53,23 +53,23 @@ export function AdminVideoContentsDetailModal({
             <div className="flex flex-col gap-1 ">
               <p className="text-sm text-ot-background">세로 (5:7)</p>
               <div className="relative w-60 aspect-5/7 rounded-lg overflow-hidden">
-                {/* <Image
+                <Image
                   src={data.posterUrl || ""}
                   alt={`${data.posterUrl} 세로 썸네일`}
                   fill
                   className="object-cover"
-                /> */}
+                />
               </div>
             </div>
             <div className="flex flex-col gap-1">
               <p className="text-sm text-ot-background">가로 (4:3)</p>
               <div className="relative w-113 aspect-4/3 rounded-lg overflow-hidden">
-                {/* <Image
+                <Image
                   src={data.thumbnailUrl || ""}
                   alt={`${data.thumbnailUrl} 가로 썸네일`}
                   fill
                   className="object-cover"
-                /> */}
+                />
               </div>
             </div>
           </div>

--- a/src/features/video-contents-manage/components/AdminVideoContentsEditModal.tsx
+++ b/src/features/video-contents-manage/components/AdminVideoContentsEditModal.tsx
@@ -1,11 +1,12 @@
 "use client";
-
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useTagsByCategory } from "@/entities/statistics/hooks";
 import { X } from "lucide-react";
 import { AdminContentTypeSelector } from "@features/video-contents-manage/components";
 import { AdminCategoryDropdown } from "@entities/category/components";
 import { useCategories } from "@entities/category/hooks";
+import { SeriesListItem } from "@entities/series/apis";
 import { AdminSeriesDropdown } from "@entities/series/components";
 import { AdminTagDropdown } from "@entities/tag/components";
 import {
@@ -19,20 +20,11 @@ import {
   AdminPublicStatus,
   AdminTextInput,
   CommonButton,
+  ConfirmModal,
   PosterState,
 } from "@shared/components";
 import { uploadFileToS3 } from "@shared/lib";
-import { ContentType, PublicStatus, TAGS } from "@shared/types";
-
-// FIXME: series 조회 api 필요 (현재는 고정값)
-const SERIES_LIST = [
-  "시리즈 없음",
-  "더글로리 시즌1",
-  "선재 업고 튀어",
-  "흑백 요리사 시즌1",
-  "흑백 요리사 시즌2",
-  "대탈출 1",
-];
+import { ContentType, PublicStatus } from "@shared/types";
 
 interface AdminVideoContentsEditModalProps {
   mediaId: number;
@@ -49,18 +41,25 @@ export function AdminVideoContentsEditModal({
   const { data: categories } = useCategories();
   const { mutateAsync: updateVideo, isPending } = useUpdateVideoContents();
 
-  const [isInitialized, setIsInitialized] = useState<boolean>(false); // 초기 데이터 세팅 여부
+  const [isInitialized, setIsInitialized] = useState<boolean>(false);
+  const [isTagInitialized, setIsTagInitialized] = useState<boolean>(false);
   const [title, setTitle] = useState<string>("");
   const [description, setDescription] = useState<string>("");
   const [cast, setCast] = useState<string>("");
   const [isPublic, setIsPublic] = useState<PublicStatus>("PUBLIC");
-  const [selectedSeries, setSelectedSeries] = useState<string | null>(null);
+  const [selectedSeries, setSelectedSeries] = useState<number | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
   const [poster, setPoster] = useState<PosterState>({
     posterUrl: null,
     thumbnailUrl: null,
   });
+  const [contentType, setContentType] = useState<ContentType>("단편");
+  const [uploadError, setUploadError] = useState<boolean>(false);
+
+  const { data: tagList } = useTagsByCategory(selectedCategory);
+  const tags = tagList ?? [];
+  const formRef = useRef<HTMLFormElement>(null);
 
   useEffect(() => {
     if (!data || isInitialized || !categories) return;
@@ -68,22 +67,13 @@ export function AdminVideoContentsEditModal({
     setDescription(data.description);
     setCast(data.actors);
     setIsPublic(data.publicStatus);
-    setSelectedSeries(data.seriesTitle);
+    setContentType(data.seriesTitle ? "시리즈" : "단편");
+    setSelectedSeries(null); // TODO: API 응답에 seriesId 추가되면 setSelectedSeries(data.seriesId ?? null) 로 교체
 
     const categoryId =
       categories.find((c) => c.categoryName === data.categoryName)
         ?.categoryId ?? null;
     setSelectedCategory(categoryId);
-
-    setSelectedTags(
-      categoryId
-        ? data.tagNameList
-            .map(
-              (name) => TAGS[categoryId]?.find((t) => t.name === name)?.tagId,
-            )
-            .filter((id): id is number => id !== undefined)
-        : [],
-    );
 
     setPoster({
       posterUrl: data.posterUrl,
@@ -91,6 +81,17 @@ export function AdminVideoContentsEditModal({
     });
     setIsInitialized(true);
   }, [data, isInitialized, categories]);
+
+  // tagList가 로드된 후 태그 초기화 (최초 1회만)
+  useEffect(() => {
+    if (!data || !tagList || isTagInitialized) return;
+    setSelectedTags(
+      data.tagNameList
+        .map((name) => tagList.find((t) => t.name === name)?.tagId)
+        .filter((id): id is number => id !== undefined),
+    );
+    setIsTagInitialized(true);
+  }, [data, tagList, isTagInitialized]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -109,18 +110,11 @@ export function AdminVideoContentsEditModal({
 
   if (isLoading) return <div>로딩중...</div>;
   if (isError || !data) return <div>에러</div>;
-
   if (typeof document === "undefined") return null;
 
-  // seriesTitle이 null이면 "단편", 값이 있으면 "시리즈"로 파생
-  const contentType: ContentType = selectedSeries ? "시리즈" : "단편";
-
   const handleContentTypeChange = (type: ContentType) => {
-    if (type === "단편") {
-      setSelectedSeries(null);
-      return;
-    }
-    setSelectedSeries(data.seriesTitle ?? "시리즈 없음");
+    setContentType(type);
+    if (type === "단편") setSelectedSeries(null);
   };
 
   const handleCategoryChange = (category: number | null) => {
@@ -128,9 +122,20 @@ export function AdminVideoContentsEditModal({
     setSelectedTags([]);
   };
 
+  const handleSeriesChange = (
+    seriesId: number | null,
+    item: SeriesListItem | null,
+  ) => {
+    setSelectedSeries(seriesId);
+    // TODO: API에 seriesId 기반 categoryId, tagIdList 추가되면 자동 세팅
+    // if (item) {
+    //   setSelectedCategory(item.categoryId);
+    //   setSelectedTags(item.tagIdList);
+    // }
+  };
+
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-
     if (!selectedCategory) return;
 
     const body: UploadVideoRequest = {
@@ -141,22 +146,17 @@ export function AdminVideoContentsEditModal({
       categoryId: selectedCategory,
       tagIdList: selectedTags,
       seriesId:
-        contentType === "시리즈" && selectedSeries
-          ? Number(selectedSeries)
-          : undefined,
+        contentType === "시리즈" ? (selectedSeries ?? undefined) : undefined,
       posterFileName: poster.posterFile?.name,
       thumbnailFileName: poster.thumbnailFile?.name,
     };
 
-    // FIXME: 서버 수정 api 새로 업데이트되면 콘솔 확인 후 콘솔 제거한 코드로 교체할 예정
     try {
-      // 1️⃣ 메타데이터 전송 → Presigned URL 수신
       const { posterUploadUrl, thumbnailUploadUrl } = await updateVideo({
-        contentsId: mediaId,
+        contentsId: data.contentsId,
         body,
       });
 
-      // 2️⃣ S3 직접 업로드 (개별 확인)
       const s3Results = await Promise.allSettled([
         poster.posterFile
           ? uploadFileToS3(posterUploadUrl, poster.posterFile).then(
@@ -173,17 +173,17 @@ export function AdminVideoContentsEditModal({
       const failed = s3Results.filter((r) => r.status === "rejected");
       if (failed.length > 0) {
         console.error("실패한 업로드:", failed);
+        setUploadError(true);
         return;
       }
 
-      // 3️⃣ 로컬 상태 업데이트 후 모달 닫기
-      const tagNameList = selectedTags
-        .map((id) => TAGS[selectedCategory]?.find((t) => t.tagId === id)?.name)
-        .filter((name): name is string => name !== undefined);
+      const tagNameList = tags
+        .filter((t) => selectedTags.includes(t.tagId))
+        .map((t) => t.name);
 
       onUpdate({
         ...data,
-        seriesTitle: selectedSeries ?? null,
+        seriesTitle: selectedSeries ? String(selectedSeries) : null,
         title,
         description,
         categoryName: data.categoryName,
@@ -197,109 +197,128 @@ export function AdminVideoContentsEditModal({
       onClose();
     } catch (error) {
       console.error("수정 실패:", error);
+      setUploadError(true);
     }
   };
-  return createPortal(
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={onClose}
-    >
-      <div
-        className="relative w-218 bg-ot-text rounded-lg py-6 px-8 shadow-xl overflow-y-auto max-h-[90vh]"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* 헤더 */}
-        <div className="relative mb-8 text-ot-background">
-          <p className="text-2xl font-bold">콘텐츠 정보 수정</p>
-          <button
-            onClick={onClose}
-            className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"
-          >
-            <X size={22} />
-          </button>
-        </div>
 
-        <form
-          className="grid gap-y-6 text-ot-background"
-          onSubmit={handleSubmit}
+  const handleRetry = () => {
+    setUploadError(false);
+    requestAnimationFrame(() => {
+      formRef.current?.requestSubmit();
+    });
+  };
+
+  return (
+    <>
+      {createPortal(
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={onClose}
         >
-          <AdminContentTypeSelector
-            value={contentType}
-            onChange={handleContentTypeChange}
-          />
+          <div
+            className="relative w-218 bg-ot-text rounded-lg py-6 px-8 shadow-xl overflow-y-auto max-h-[90vh]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="relative mb-8 text-ot-background">
+              <p className="text-2xl font-bold">콘텐츠 정보 수정</p>
+              <button
+                onClick={onClose}
+                className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"
+              >
+                <X size={22} />
+              </button>
+            </div>
 
-          <AdminTextInput
-            label="제목"
-            placeholder='콘텐츠 제목을 입력하세요 (예: "시리즈명: 1화")'
-            value={title}
-            onChange={setTitle}
-          />
-
-          <AdminTextInput
-            label="설명"
-            placeholder="콘텐츠 설명을 입력하세요"
-            multiline
-            value={description}
-            onChange={setDescription}
-          />
-
-          <AdminTextInput
-            label="출연"
-            placeholder="출연진은 쉼표(,)로 구분해 입력해 주세요 (예: 임지연, 송혜교, 이도현 · 최대 4인)"
-            value={cast}
-            onChange={setCast}
-          />
-
-          {/* 시리즈 드롭다운: 타입이 "시리즈"일 때만 활성화 */}
-          <div className="grid grid-cols-2 gap-6">
-            <AdminSeriesDropdown
-              seriesList={SERIES_LIST}
-              value={selectedSeries}
-              onChange={setSelectedSeries}
-              disabled={contentType === "단편"}
-            />
-            <AdminPublicStatus
-              isPublic={isPublic === "PUBLIC"}
-              onChange={(bool) => setIsPublic(bool ? "PUBLIC" : "PRIVATE")}
-            />
-          </div>
-
-          {/* 카테고리 + 태그 */}
-          <div className="grid grid-cols-2 gap-6">
-            <AdminCategoryDropdown
-              value={selectedCategory}
-              onChange={handleCategoryChange}
-            />
-            <AdminTagDropdown
-              category={selectedCategory}
-              value={selectedTags}
-              onChange={setSelectedTags}
-            />
-          </div>
-
-          {/* <AdminPosterUpload value={poster} onChange={setPoster} /> */}
-
-          {/* 버튼 */}
-          <div className="grid grid-cols-2 gap-4">
-            <CommonButton
-              type="button"
-              onClick={onClose}
-              className="py-3 font-semibold"
-              variant="outline"
+            <form
+              ref={formRef}
+              className="grid gap-y-6 text-ot-background"
+              onSubmit={handleSubmit}
             >
-              취소
-            </CommonButton>
-            <CommonButton
-              type="submit"
-              className="py-3 font-semibold"
-              disabled={isPending}
-            >
-              {isPending ? "수정 중..." : "수정 완료"}
-            </CommonButton>
+              <AdminContentTypeSelector
+                value={contentType}
+                onChange={handleContentTypeChange}
+              />
+
+              <AdminTextInput
+                label="제목"
+                placeholder='콘텐츠 제목을 입력하세요 (예: "시리즈명: 1화")'
+                value={title}
+                onChange={setTitle}
+              />
+
+              <AdminTextInput
+                label="설명"
+                placeholder="콘텐츠 설명을 입력하세요"
+                multiline
+                value={description}
+                onChange={setDescription}
+              />
+
+              <AdminTextInput
+                label="출연"
+                placeholder="출연진은 쉼표(,)로 구분해 입력해 주세요 (예: 임지연, 송혜교, 이도현 · 최대 4인)"
+                value={cast}
+                onChange={setCast}
+              />
+
+              <div className="grid grid-cols-2 gap-6">
+                <AdminSeriesDropdown
+                  value={selectedSeries}
+                  onChange={handleSeriesChange}
+                  disabled={contentType === "단편"}
+                />
+                <AdminPublicStatus
+                  isPublic={isPublic === "PUBLIC"}
+                  onChange={(bool) => setIsPublic(bool ? "PUBLIC" : "PRIVATE")}
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-6">
+                <AdminCategoryDropdown
+                  value={selectedCategory}
+                  onChange={handleCategoryChange}
+                />
+                <AdminTagDropdown
+                  category={selectedCategory}
+                  value={selectedTags}
+                  onChange={setSelectedTags}
+                />
+              </div>
+
+              <AdminPosterUpload value={poster} onChange={setPoster} />
+
+              <div className="grid grid-cols-2 gap-4">
+                <CommonButton
+                  type="button"
+                  onClick={onClose}
+                  className="py-3 font-semibold"
+                  variant="outline"
+                >
+                  취소
+                </CommonButton>
+                <CommonButton
+                  type="submit"
+                  className="py-3 font-semibold"
+                  disabled={isPending}
+                >
+                  {isPending ? "수정 중..." : "수정 완료"}
+                </CommonButton>
+              </div>
+            </form>
           </div>
-        </form>
-      </div>
-    </div>,
-    document.body,
+        </div>,
+        document.body,
+      )}
+
+      <ConfirmModal
+        isOpen={uploadError}
+        message={"수정에 실패했습니다.\n다시 시도하시겠습니까?"}
+        confirmText="재시도"
+        cancelText="취소"
+        onConfirm={handleRetry}
+        onClose={() => setUploadError(false)}
+        disabled={isPending}
+      />
+    </>
   );
 }

--- a/src/features/video-contents-manage/components/AdminVideoContentsList.tsx
+++ b/src/features/video-contents-manage/components/AdminVideoContentsList.tsx
@@ -36,16 +36,16 @@ export function AdminVideoContentsList({
   const hasSelectedMediaId =
     selectedMediaId !== null && Number.isFinite(selectedMediaId);
 
-  const handleRowClick = (id: number) => {
-    router.push(`?id=${id}`, { scroll: false });
+  const handleRowClick = (mediaId: number) => {
+    router.push(`?id=${mediaId}`, { scroll: false });
   };
 
   const handleClose = () => {
     router.push("?", { scroll: false });
   };
 
-  const handleEditClick = (id: number) => {
-    router.push(`?id=${id}&action=edit`, { scroll: false });
+  const handleEditClick = (mediaId: number) => {
+    router.push(`?id=${mediaId}&action=edit`, { scroll: false });
   };
 
   if (isLoading) return <div>로딩 중...</div>;
@@ -83,19 +83,22 @@ export function AdminVideoContentsList({
                 <td className="py-3">
                   <div className="relative aspect-5/7 max-w-12 w-full mx-auto">
                     {content.posterUrl ? (
-                      <div>{content.posterUrl} 예시</div>
+                      <>
+                        <Image
+                          src={content.posterUrl}
+                          alt={content.title}
+                          fill
+                          className="object-cover rounded-md"
+                        />
+                        <div
+                          className="w-full h-full rounded-md bg-ot-gray-800"
+                          aria-label="썸네일 없음"
+                        />
+                      </>
                     ) : (
-                      // TODO: 썸네일 넣어야 함
-                      // <Image
-                      //   src={content.posterUrl}
-                      //   alt={content.title}
-                      //   fill
-                      //   className="object-cover rounded-md"
-                      // />
-                      <div
-                        className="w-full h-full rounded-md bg-ot-gray-800"
-                        aria-label="썸네일 없음"
-                      />
+                      <div className="flex items-center justify-center w-full h-full rounded-md bg-ot-gray-800 text-ot-gray-700">
+                        <span className="text-xl font-bold">✕</span>
+                      </div>
                     )}
                   </div>
                 </td>

--- a/src/features/video-contents-manage/components/AdminVideoContentsUploadModal.tsx
+++ b/src/features/video-contents-manage/components/AdminVideoContentsUploadModal.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { SeriesListItem } from "@/entities/series/apis";
 import { X } from "lucide-react";
 import { AdminContentTypeSelector } from "@features/video-contents-manage/components";
 import { AdminCategoryDropdown } from "@entities/category/components";
@@ -18,24 +19,14 @@ import {
   ConfirmModal,
   PosterState,
 } from "@shared/components";
-import { uploadFileToS3 } from "@shared/lib";
 import { useIsMounted } from "@shared/hooks";
+import { uploadFileToS3 } from "@shared/lib";
 import { ContentType, VideoFileMeta } from "@shared/types";
 
 interface AdminUploadModalProps {
   open: boolean;
   onClose: () => void;
 }
-
-// FIXME: 시리즈 목록 API 연동 필요
-const SERIES_LIST = [
-  "시리즈 없음",
-  "더글로리",
-  "선재 업고 튀어",
-  "흑백 요리사 시즌1",
-  "흑백 요리사 시즌2",
-  "대탈출 1",
-];
 
 export function AdminVideoContentsUploadModal({
   open,
@@ -63,7 +54,7 @@ function ModalInner({ onClose }: { onClose: () => void }) {
   const [cast, setCast] = useState("");
   const [isPublic, setIsPublic] = useState(false);
   const [videoFile, setVideoFile] = useState<VideoFileMeta | null>(null);
-  const [selectedSeries, setSelectedSeries] = useState<string | null>(null);
+  const [selectedSeries, setSelectedSeries] = useState<number | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
   const [poster, setPoster] = useState<PosterState>({
@@ -71,7 +62,7 @@ function ModalInner({ onClose }: { onClose: () => void }) {
     thumbnailUrl: null,
   });
   const [contentType, setContentType] = useState<ContentType>("단편");
-  const [uploadError, setUploadError] = useState(false);
+  const [uploadError, setUploadError] = useState<boolean>(false);
 
   const formRef = useRef<HTMLFormElement>(null);
 
@@ -93,6 +84,17 @@ function ModalInner({ onClose }: { onClose: () => void }) {
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [onClose]);
+
+  const handleSeriesChange = (
+    seriesId: number | null,
+    item: SeriesListItem | null,
+  ) => {
+    setSelectedSeries(seriesId);
+    if (!item) {
+      setSelectedCategory(null);
+      setSelectedTags([]);
+    }
+  };
 
   const handleCategoryChange = (category: number | null) => {
     setSelectedCategory(category);
@@ -117,9 +119,7 @@ function ModalInner({ onClose }: { onClose: () => void }) {
       duration: videoFile!.duration,
       videoSize: videoFile!.size,
       seriesId:
-        contentType === "시리즈" && selectedSeries
-          ? Number(selectedSeries)
-          : undefined,
+        contentType === "시리즈" ? (selectedSeries ?? undefined) : undefined,
       posterFileName: poster.posterFile?.name,
       thumbnailFileName: poster.thumbnailFile?.name,
       originFileName: videoFile!.name,
@@ -219,9 +219,8 @@ function ModalInner({ onClose }: { onClose: () => void }) {
               {/* 시리즈 + 공개 여부 */}
               <div className="grid grid-cols-2 gap-6">
                 <AdminSeriesDropdown
-                  seriesList={SERIES_LIST}
                   value={selectedSeries}
-                  onChange={setSelectedSeries}
+                  onChange={handleSeriesChange}
                   disabled={contentType !== "시리즈"}
                 />
                 <AdminPublicStatus isPublic={isPublic} onChange={setIsPublic} />


### PR DESCRIPTION
## 📝 작업 내용

> **콘텐츠 수정 API 연동, 콘텐츠 업로드 최종 구현 완료**
> - 현재 `콘텐츠 수정 - 단편` 은 잘 되나, `콘텐츠 수정 - 시리즈` 부분은 추후 백엔드 작업 완료 시 다시 테스트 해보고 수정해야 할 듯 합니다. 
>    - `콘텐츠 수정 - 시리즈` 할 때, 시리즈 드롭다운을 현재는 GET `/admin/series`으로 쓰고 있으나 백엔드에서 GET `/admin/series/titles`에 응답필드값을 추가해주신다고 해서 해당 API로 수정될 예정입니다. (콘텐츠 업로드 모달 - 시리즈 드롭다운 마찬가지)
> - `next.config.ts` 에 image remotePatterns 추가

## 📷 스크린샷

- 콘텐츠 업로드 (단편/시리즈 잘 됨)


https://github.com/user-attachments/assets/63addfd1-1f73-49e9-8a7f-421930f90e25


- 콘텐츠 수정 (단편만)

https://github.com/user-attachments/assets/cf3d141f-1342-4cbe-a0ee-218ccc30a906




## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`next.config.ts`

- next에서 제공하는 Image 태그 사용시, 외부 경로인 경우 remotePatterns 등록이 필수입니다.

```ts
const nextConfig: NextConfig = {
  /* config options here */
  reactCompiler: true,
  images: {
    remotePatterns: [
      {
        protocol: "https",
        hostname: "oplust-content-0370aace.s3.ap-northeast-2.amazonaws.com",
      },
      {
        protocol: "https",
        hostname: "cdn.openthetaste.cloud",
      },
    ],
  },
};

```

## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #21 

## 💬 리뷰 요구사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시리즈 및 태그 드롭다운이 동적 API 기반으로 변경되었습니다.
  * 이미지 최적화 기능이 추가되었습니다.

* **버그 수정**
  * 태그 로딩 중 및 오류 상태 표시가 개선되었습니다.
  * 카테고리 5, 6에 대한 색상 매핑이 활성화되었습니다.
  * 비디오 콘텐츠 썸네일이 정상적으로 표시되도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->