### PR TITLE
[OT-236] [FEAT]: 백오피스 - 숏폼 업로드, 수정 API 연동

### DIFF
--- a/src/entities/originMedia/apis/getOriginMedia.ts
+++ b/src/entities/originMedia/apis/getOriginMedia.ts
@@ -1,7 +1,7 @@
 import { api } from "@/shared/api";
 import { ApiResponse, BasePaginationParams, PageInfo } from "@/shared/types";
 
-export type OriginMediaType = "CONTENTS" | "SERIRES";
+export type OriginMediaType = "CONTENTS" | "SERIES";
 
 export interface OriginMediaItem {
   originId: number;

--- a/src/entities/originMedia/apis/getOriginMedia.ts
+++ b/src/entities/originMedia/apis/getOriginMedia.ts
@@ -1,0 +1,24 @@
+import { api } from "@/shared/api";
+import { ApiResponse, BasePaginationParams, PageInfo } from "@/shared/types";
+
+export type OriginMediaType = "CONTENTS" | "SERIRES";
+
+export interface OriginMediaItem {
+  originId: number;
+  title: string;
+  mediaType: OriginMediaType;
+}
+
+export interface OriginMediaResponse {
+  pageInfo: PageInfo;
+  dataList: OriginMediaItem[];
+}
+
+// 원본콘텐츠 조회 API
+export const getOriginMediaApi = async (params: BasePaginationParams) => {
+  const res = await api.get<ApiResponse<OriginMediaResponse>>(
+    "/short-forms/origin-media",
+    { params },
+  );
+  return res.data.data;
+};

--- a/src/entities/originMedia/apis/index.ts
+++ b/src/entities/originMedia/apis/index.ts
@@ -1,0 +1,1 @@
+export * from "./getOriginMedia";

--- a/src/entities/originMedia/components/AdminOriginalContentsDropdown.tsx
+++ b/src/entities/originMedia/components/AdminOriginalContentsDropdown.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { ChevronDown, Loader2, Search } from "lucide-react";
+import { OriginMediaItem } from "@entities/originMedia/apis";
+import { useInfiniteOriginMedia } from "@entities/originMedia/hooks";
+import { useOutsideClick } from "@shared/hooks";
+import { cn } from "@shared/utils";
+
+export interface AdminOriginalContentsDropdownProps {
+  value: OriginMediaItem | null;
+  onChange: (original: OriginMediaItem) => void;
+}
+
+export function AdminOriginalContentsDropdown({
+  value,
+  onChange,
+}: AdminOriginalContentsDropdownProps) {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [search, setSearch] = useState<string>("");
+  const [inputValue, setInputValue] = useState<string>("");
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const { originMediaList, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useInfiniteOriginMedia({
+      size: 10,
+      searchWord: search || undefined,
+    });
+
+  useOutsideClick(dropdownRef, () => setIsOpen(false), isOpen);
+
+  const handleSelect = (item: OriginMediaItem) => {
+    onChange(item);
+    setIsOpen(false);
+    setSearch("");
+    setInputValue("");
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      setSearch(inputValue);
+    }
+  };
+
+  // 스크롤 핸들러: 스크롤이 바닥에 가까워지면 다음 페이지를 불러옴
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
+    if (scrollHeight - scrollTop <= clientHeight + 10) {
+      if (hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
+    }
+  };
+  return (
+    <div>
+      <p className="font-semibold text-lg mb-2">원본 콘텐츠 선택</p>
+
+      <div ref={dropdownRef} className="relative">
+        <button
+          type="button"
+          onClick={() => {
+            setIsOpen((prev) => !prev);
+            setSearch("");
+            setInputValue("");
+          }}
+          className="w-full flex items-center justify-between border border-ot-gray-600 rounded-lg py-3 px-4 text-sm text-left bg-ot-text hover:bg-ot-gray-200 transition-colors cursor-pointer"
+        >
+          <span
+            className={cn(value ? "text-ot-background" : "text-ot-gray-600")}
+          >
+            {value?.title ?? "원본 콘텐츠 선택"}
+          </span>
+          <ChevronDown
+            size={16}
+            className={cn(
+              "text-ot-gray-600 shrink-0 transition-transform duration-200",
+              isOpen && "rotate-180",
+            )}
+          />
+        </button>
+
+        {isOpen && (
+          <div className="absolute top-full left-0 right-0 z-20 mt-1 bg-ot-text rounded-lg shadow-lg">
+            {/* 검색창 */}
+            <div className="flex items-center gap-2 px-3 py-2 border border-ot-gray-600 rounded-lg m-1">
+              <input
+                type="text"
+                autoFocus
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="원본 콘텐츠 검색 (Enter)"
+                className="flex-1 text-sm placeholder:text-ot-gray-600 outline-none text-ot-background"
+              />
+              <button
+                type="button"
+                onClick={() => setSearch(inputValue)}
+                className="cursor-pointer"
+              >
+                <Search size={15} className="text-ot-gray-600 shrink-0" />
+              </button>
+            </div>
+
+            {/* 목록 + 무한스크롤 */}
+            <div className="max-h-48 overflow-y-auto" onScroll={handleScroll}>
+              {originMediaList.length > 0 ? (
+                <>
+                  {originMediaList.map((item) => (
+                    <button
+                      type="button"
+                      key={item.originId}
+                      onClick={() => handleSelect(item)}
+                      className={cn(
+                        "w-full text-left px-4 py-3 text-sm transition-colors cursor-pointer",
+                        value?.originId === item.originId
+                          ? "bg-ot-primary-gradient text-ot-text"
+                          : "text-ot-background hover:bg-ot-gray-200",
+                      )}
+                    >
+                      {item.title}
+                    </button>
+                  ))}
+                  {/* 무한스크롤 트리거 */}
+                  <div className="py-1 flex justify-center">
+                    {isFetchingNextPage && (
+                      <Loader2
+                        className="animate-spin text-ot-placeholder"
+                        size={20}
+                      />
+                    )}
+                  </div>
+                </>
+              ) : (
+                <p className="px-4 py-3 text-sm text-ot-gray-600">
+                  검색 결과가 없습니다
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/entities/originMedia/components/index.ts
+++ b/src/entities/originMedia/components/index.ts
@@ -1,0 +1,1 @@
+export { AdminOriginalContentsDropdown } from "./AdminOriginalContentsDropdown";

--- a/src/entities/originMedia/hooks/index.ts
+++ b/src/entities/originMedia/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useInfiniteOriginMedia } from "./useOriginMediaList";

--- a/src/entities/originMedia/hooks/useOriginMediaList.ts
+++ b/src/entities/originMedia/hooks/useOriginMediaList.ts
@@ -1,0 +1,39 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { OriginMediaItem, getOriginMediaApi } from "@entities/originMedia/apis";
+import { useInfiniteScroll } from "@shared/hooks";
+
+interface UseInfiniteOriginMediaParams {
+  size?: number;
+  searchWord?: string;
+}
+
+export const useInfiniteOriginMedia = ({
+  size = 10,
+  searchWord,
+}: UseInfiniteOriginMediaParams = {}) => {
+  const query = useInfiniteQuery({
+    queryKey: ["origin-media", "list", { size, searchWord }],
+    queryFn: ({ pageParam = 0 }) =>
+      getOriginMediaApi({
+        page: pageParam as number,
+        size,
+        searchWord,
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      const { currentPage, totalPage } = lastPage.pageInfo;
+      return currentPage + 1 < totalPage ? currentPage + 1 : undefined;
+    },
+  });
+
+  const { observerRef } = useInfiniteScroll({
+    hasNextPage: query.hasNextPage,
+    isFetchingNextPage: query.isFetchingNextPage,
+    fetchNextPage: query.fetchNextPage,
+  });
+
+  const originMediaList: OriginMediaItem[] =
+    query.data?.pages.flatMap((page) => page.dataList) ?? [];
+
+  return { ...query, originMediaList, observerRef };
+};

--- a/src/entities/shorts/apis/index.ts
+++ b/src/entities/shorts/apis/index.ts
@@ -1,1 +1,2 @@
 export * from "./getShortsApi";
+export * from "./shortsApi";

--- a/src/entities/shorts/apis/shortsApi.ts
+++ b/src/entities/shorts/apis/shortsApi.ts
@@ -3,7 +3,7 @@ import { ApiResponse, PublicStatus } from "@shared/types";
 
 export interface UploadShortsRequest {
   originId: number;
-  mediaType: string;
+  mediaType: "CONTENTS" | "SERIES";
   title?: string;
   description?: string;
   publicStatus: PublicStatus;
@@ -36,7 +36,7 @@ export const uploadShortsApi = async (body: UploadShortsRequest) => {
 
 export interface UpdateShortsRequest {
   originId: number;
-  mediaType: string;
+  mediaType: "CONTENTS" | "SERIES";
   title?: string;
   description?: string;
   publicStatus: PublicStatus;

--- a/src/entities/shorts/apis/shortsApi.ts
+++ b/src/entities/shorts/apis/shortsApi.ts
@@ -1,0 +1,56 @@
+import { api } from "@shared/api";
+import { ApiResponse, PublicStatus } from "@shared/types";
+
+export interface UploadShortsRequest {
+  originId: number;
+  mediaType: string;
+  title?: string;
+  description?: string;
+  publicStatus: PublicStatus;
+  duration?: number;
+  videoSize?: number;
+  posterFileName?: string;
+  thumbnailFileName?: string;
+  originFileName?: string;
+}
+
+export interface UploadShortsResponse {
+  shortFormId: number;
+  posterObjectKey: string;
+  thumbnailObjectKey: string;
+  originObjectKey: string;
+  masterPlaylistObjectKey: string;
+  posterUploadUrl: string; // S3에 업로드할 때 사용할 URL - 포스터 이미지 파일
+  thumbnailUploadUrl: string; // S3에 업로드할 때 사용할 URL - 썸네일 이미지 파일
+  originUploadUrl: string; // S3에 업로드할 때 사용할 URL - 원본 영상 파일
+}
+
+// 콘텐츠 업로드 API
+export const uploadShortsApi = async (body: UploadShortsRequest) => {
+  const res = await api.post<ApiResponse<UploadShortsResponse>>(
+    "/short-forms/upload",
+    body,
+  );
+  return res.data.data;
+};
+
+export interface UpdateShortsRequest {
+  originId: number;
+  mediaType: string;
+  title?: string;
+  description?: string;
+  publicStatus: PublicStatus;
+  posterFileName?: string;
+}
+
+// 콘텐츠 수정 API
+export const updateShortsApi = async (
+  shortformId: number,
+  body: UpdateShortsRequest,
+) => {
+  const res = await api.patch<ApiResponse<UploadShortsResponse>>(
+    `/short-forms/${shortformId}/upload`,
+    body,
+  );
+  return res.data.data;
+};

--- a/src/entities/shorts/components/AdminShortsDetailModal.tsx
+++ b/src/entities/shorts/components/AdminShortsDetailModal.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { Bookmark, X } from "lucide-react";
 import { CategoryBadge } from "@entities/category/components";
+import { useCategories } from "@entities/category/hooks";
 import { useShortsDetail } from "@entities/shorts/hooks";
 import { TagBadge } from "@entities/tag/components";
 import { AdminPublicBadge } from "@shared/components";
@@ -18,9 +19,14 @@ export function AdminShortsDetailModal({
   onClose,
 }: AdminShortsDetailModalProps) {
   const { data, isLoading, isError } = useShortsDetail(mediaId);
+  const { data: categories } = useCategories();
 
   if (isLoading) return <div>로딩중...</div>;
   if (isError || !data) return <div>에러</div>;
+
+  const categoryId =
+    categories?.find((c) => c.categoryName === data.categoryName)?.categoryId ??
+    null;
 
   return (
     <div
@@ -49,18 +55,22 @@ export function AdminShortsDetailModal({
             <p className="text-base font-semibold">썸네일 (5:7)</p>
             <div className="relative max-w-60 aspect-5/7 rounded-lg overflow-hidden">
               {data.posterUrl ? (
-                // <Image
-                //   src={data.posterUrl}
-                //   alt={`${data.title} 세로 썸네일`}
-                //   fill
-                //   className="object-cover"
-                // />
-                <div>{data.posterUrl} 예시</div>
+                <>
+                  <Image
+                    src={data.posterUrl}
+                    alt={data.title}
+                    fill
+                    className="object-cover rounded-md"
+                  />
+                  <div
+                    className="w-full h-full rounded-md bg-ot-gray-800"
+                    aria-label="썸네일 없음"
+                  />
+                </>
               ) : (
-                <div
-                  className="w-full h-full bg-ot-gray-200"
-                  aria-label="썸네일 없음"
-                />
+                <div className="flex items-center justify-center w-full h-full rounded-md bg-ot-gray-800 text-ot-gray-700">
+                  <span className="text-xl font-bold">✕</span>
+                </div>
               )}
             </div>
           </div>
@@ -104,19 +114,25 @@ export function AdminShortsDetailModal({
               <div className="flex flex-col gap-1">
                 <p className="text-base font-semibold">카테고리</p>
                 <div className="flex items-center">
-                  <CategoryBadge category={data.categoryName} />
+                  {categoryId && (
+                    <CategoryBadge
+                      category={categoryId}
+                      label={data.categoryName}
+                    />
+                  )}
                 </div>
               </div>
               <div className="flex flex-col gap-1">
                 <p className="text-base font-semibold">태그</p>
                 <div className="flex items-center gap-2 flex-wrap">
-                  {data.tagNameList.map((tag) => (
-                    <TagBadge
-                      key={tag}
-                      label={tag}
-                      category={data.categoryName}
-                    />
-                  ))}
+                  {categoryId &&
+                    data.tagNameList.map((tagName) => (
+                      <TagBadge
+                        key={tagName}
+                        label={tagName}
+                        category={categoryId}
+                      />
+                    ))}
                 </div>
               </div>
             </div>

--- a/src/entities/shorts/hooks/index.ts
+++ b/src/entities/shorts/hooks/index.ts
@@ -1,1 +1,3 @@
 export { useInfiniteShortsList, useShortsDetail } from "./useShorts";
+export { useUploadShorts } from "./useUploadShorts";
+export { useUpdateShorts } from "./useUpdateShorts";

--- a/src/entities/shorts/hooks/useUpdateShorts.ts
+++ b/src/entities/shorts/hooks/useUpdateShorts.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { UpdateShortsRequest, updateShortsApi } from "@entities/shorts/apis";
+
+// 숏폼 수정
+export const useUpdateShorts = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      shortformId,
+      body,
+    }: {
+      shortformId: number;
+      body: UpdateShortsRequest;
+    }) => updateShortsApi(shortformId, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["shorts", "list"] });
+    },
+  });
+};

--- a/src/entities/shorts/hooks/useUploadShorts.ts
+++ b/src/entities/shorts/hooks/useUploadShorts.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { UploadShortsRequest, uploadShortsApi } from "@entities/shorts/apis";
+
+// 숏폼 업로드
+export const useUploadShorts = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: UploadShortsRequest) => uploadShortsApi(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["shorts", "list"] });
+    },
+  });
+};

--- a/src/features/shorts-manage/AdminShortsEditModal.tsx
+++ b/src/features/shorts-manage/AdminShortsEditModal.tsx
@@ -1,59 +1,55 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { ShortsDetailResponse } from "@/entities/shorts/apis";
-import { useShortsDetail } from "@/entities/shorts/hooks";
-import { PublicStatus } from "@/shared/types";
+import { uploadFileToS3 } from "@/shared/lib";
 import { X } from "lucide-react";
-import { ContentListItem } from "@entities/video-contents/apis";
-import { AdminOriginalContentsDropdown } from "@entities/video-contents/components";
+import { OriginMediaItem } from "@entities/originMedia/apis";
+import { AdminOriginalContentsDropdown } from "@entities/originMedia/components";
+import { UpdateShortsRequest } from "@entities/shorts/apis";
+import { useShortsDetail, useUpdateShorts } from "@entities/shorts/hooks";
 import {
   AdminPosterUpload,
   AdminPublicStatus,
   AdminTextInput,
   CommonButton,
+  ConfirmModal,
   PosterState,
 } from "@shared/components";
+import { PublicStatus } from "@shared/types";
 
 interface AdminShortsEditModalProps {
   mediaId: number;
   onClose: () => void;
-  onUpdate: (updated: ShortsDetailResponse) => void;
 }
 
 export function AdminShortsEditModal({
   mediaId,
   onClose,
-  onUpdate,
 }: AdminShortsEditModalProps) {
   const { data, isLoading, isError } = useShortsDetail(mediaId);
+  const { mutateAsync: updateShorts, isPending } = useUpdateShorts();
 
-  const [isInitialized, setIsInitialized] = useState<boolean>(false); // 초기 데이터 세팅 여부
+  const [isInitialized, setIsInitialized] = useState<boolean>(false);
   const [title, setTitle] = useState<string>("");
   const [description, setDescription] = useState<string>("");
   const [selectedOriginal, setSelectedOriginal] =
-    useState<ContentListItem | null>(null);
+    useState<OriginMediaItem | null>(null);
   const [isPublic, setIsPublic] = useState<PublicStatus>("PUBLIC");
   const [poster, setPoster] = useState<PosterState>({
     posterUrl: null,
   });
+  const [uploadError, setUploadError] = useState<boolean>(false);
+  const formRef = useRef<HTMLFormElement>(null);
 
   useEffect(() => {
     if (!data || isInitialized) return;
     setTitle(data.title);
     setDescription(data.description);
     setIsPublic(data.publicStatus);
-    setSelectedOriginal(
-      data.originContentsTitle
-        ? {
-            mediaId: 0,
-            title: data.originContentsTitle,
-            posterUrl: "",
-            uploadedDate: "",
-          }
-        : null,
-    );
+    // FIXME: 데이터 타입 추가 서버에서 추가되면 수정할 예정 (originId, title, mediaType)
+    // setSelectedOriginal(data.originContentsTitle);
+
     setPoster({
       posterUrl: data.posterUrl,
     });
@@ -80,94 +76,145 @@ export function AdminShortsEditModal({
 
   if (typeof document === "undefined") return null;
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    onUpdate({
-      ...data,
+    if (!selectedOriginal) return;
+
+    const body: UpdateShortsRequest = {
       title,
       description,
-      originContentsTitle: selectedOriginal?.title ?? data.originContentsTitle,
       publicStatus: isPublic,
-      posterUrl: poster.posterUrl ?? data.posterUrl,
-    });
+      posterFileName: poster.posterFile?.name,
+      originId: selectedOriginal.originId,
+      mediaType: selectedOriginal.mediaType,
+    };
+
+    try {
+      const { posterUploadUrl } = await updateShorts({
+        shortformId: data.shortFormId,
+        body,
+      });
+
+      let s3Result = "poster skipped";
+
+      try {
+        if (poster.posterFile) {
+          await uploadFileToS3(posterUploadUrl, poster.posterFile);
+          s3Result = "poster ✅";
+        }
+      } catch (error) {
+        setUploadError(true);
+      }
+      onClose();
+    } catch (error) {
+      console.error("수정 실패:", error);
+      setUploadError(true);
+    }
   };
 
   if (typeof document === "undefined") return null;
 
-  return createPortal(
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={onClose}
-    >
-      <div
-        className="relative w-218 bg-ot-text rounded-lg py-6 px-8 shadow-xl overflow-y-auto max-h-[90vh]"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* 헤더 */}
-        <div className="relative mb-8 text-ot-background">
-          <p className="text-2xl font-bold">숏폼 정보 수정</p>
-          <button
-            onClick={onClose}
-            className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"
-          >
-            <X size={22} />
-          </button>
-        </div>
+  const handleRetry = () => {
+    setUploadError(false);
+    requestAnimationFrame(() => {
+      formRef.current?.requestSubmit();
+    });
+  };
 
-        <form
-          className="flex flex-col gap-6 text-ot-background"
-          onSubmit={handleSubmit}
+  return (
+    <>
+      {createPortal(
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={onClose}
         >
-          <AdminTextInput
-            label="제목"
-            placeholder="숏폼 제목을 입력하세요"
-            value={title}
-            onChange={setTitle}
-          />
-
-          <AdminTextInput
-            label="설명"
-            placeholder="숏폼 설명을 입력하세요"
-            multiline
-            value={description}
-            onChange={setDescription}
-          />
-
-          {/* 원본콘텐츠·공개여부 + 포스터 */}
-          <div className="grid grid-cols-2 gap-12">
-            {/* 좌측 */}
-            <div className="flex flex-col gap-6">
-              <AdminOriginalContentsDropdown
-                value={selectedOriginal}
-                onChange={setSelectedOriginal}
-              />
-              <AdminPublicStatus
-                isPublic={isPublic === "PUBLIC"}
-                onChange={(bool) => setIsPublic(bool ? "PUBLIC" : "PRIVATE")}
-              />
+          <div
+            className="relative w-218 bg-ot-text rounded-lg py-6 px-8 shadow-xl overflow-y-auto max-h-[90vh]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* 헤더 */}
+            <div className="relative mb-8 text-ot-background">
+              <p className="text-2xl font-bold">숏폼 정보 수정</p>
+              <button
+                onClick={onClose}
+                className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"
+              >
+                <X size={22} />
+              </button>
             </div>
 
-            {/* 우측 */}
-            {/* <AdminPosterUpload value={poster} onChange={setPoster} isShorts /> */}
-          </div>
-
-          {/* 버튼 */}
-          <div className="grid grid-cols-2 gap-4">
-            <CommonButton
-              type="button"
-              onClick={onClose}
-              className="py-3 font-semibold"
-              variant="outline"
+            <form
+              ref={formRef}
+              className="flex flex-col gap-6 text-ot-background"
+              onSubmit={handleSubmit}
             >
-              취소
-            </CommonButton>
-            <CommonButton type="submit" className="py-3 font-semibold">
-              수정 완료
-            </CommonButton>
+              <AdminTextInput
+                label="제목"
+                placeholder="숏폼 제목을 입력하세요"
+                value={title}
+                onChange={setTitle}
+              />
+
+              <AdminTextInput
+                label="설명"
+                placeholder="숏폼 설명을 입력하세요"
+                multiline
+                value={description}
+                onChange={setDescription}
+              />
+
+              {/* 원본콘텐츠·공개여부 + 포스터 */}
+              <div className="grid grid-cols-2 gap-12">
+                {/* 좌측 */}
+                <div className="flex flex-col gap-6">
+                  <AdminOriginalContentsDropdown
+                    value={selectedOriginal}
+                    onChange={setSelectedOriginal}
+                  />
+                  <AdminPublicStatus
+                    isPublic={isPublic === "PUBLIC"}
+                    onChange={(bool) =>
+                      setIsPublic(bool ? "PUBLIC" : "PRIVATE")
+                    }
+                  />
+                </div>
+
+                {/* 우측 */}
+                <AdminPosterUpload
+                  value={poster}
+                  onChange={setPoster}
+                  isShorts
+                />
+              </div>
+
+              {/* 버튼 */}
+              <div className="grid grid-cols-2 gap-4">
+                <CommonButton
+                  type="button"
+                  onClick={onClose}
+                  className="py-3 font-semibold"
+                  variant="outline"
+                >
+                  취소
+                </CommonButton>
+                <CommonButton type="submit" className="py-3 font-semibold">
+                  수정 완료
+                </CommonButton>
+              </div>
+            </form>
           </div>
-        </form>
-      </div>
-    </div>,
-    document.body,
+        </div>,
+        document.body,
+      )}
+      <ConfirmModal
+        isOpen={uploadError}
+        message={"수정에 실패했습니다.\n다시 시도하시겠습니까?"}
+        confirmText="재시도"
+        cancelText="취소"
+        onConfirm={handleRetry}
+        onClose={() => setUploadError(false)}
+        disabled={isPending}
+      />
+    </>
   );
 }

--- a/src/features/shorts-manage/AdminShortsEditModal.tsx
+++ b/src/features/shorts-manage/AdminShortsEditModal.tsx
@@ -102,10 +102,10 @@ export function AdminShortsEditModal({
           await uploadFileToS3(posterUploadUrl, poster.posterFile);
           s3Result = "poster ✅";
         }
+        onClose();
       } catch (error) {
         setUploadError(true);
       }
-      onClose();
     } catch (error) {
       console.error("수정 실패:", error);
       setUploadError(true);
@@ -194,11 +194,16 @@ export function AdminShortsEditModal({
                   onClick={onClose}
                   className="py-3 font-semibold"
                   variant="outline"
+                  disabled={isPending}
                 >
                   취소
                 </CommonButton>
-                <CommonButton type="submit" className="py-3 font-semibold">
-                  수정 완료
+                <CommonButton
+                  type="submit"
+                  className="py-3 font-semibold"
+                  disabled={isPending}
+                >
+                  {isPending ? "수정 중..." : "수정 완료"}
                 </CommonButton>
               </div>
             </form>

--- a/src/features/shorts-manage/AdminShortsList.tsx
+++ b/src/features/shorts-manage/AdminShortsList.tsx
@@ -81,18 +81,22 @@ export function AdminShortsList({
                 <td className="py-3">
                   <div className="relative aspect-5/7 max-w-12 w-full mx-auto">
                     {short.posterUrl ? (
-                      <div>{short.posterUrl} 예시</div>
+                      <>
+                        <Image
+                          src={short.posterUrl}
+                          alt={short.title}
+                          fill
+                          className="object-cover rounded-md"
+                        />
+                        <div
+                          className="w-full h-full rounded-md bg-ot-gray-800"
+                          aria-label="썸네일 없음"
+                        />
+                      </>
                     ) : (
-                      // <Image
-                      //   src={short.thumbnailUrl}
-                      //   alt={short.title}
-                      //   fill
-                      //   className="object-cover rounded-md"
-                      // />
-                      <div
-                        className="w-full h-full rounded-md bg-ot-gray-800"
-                        aria-label="썸네일 없음"
-                      />
+                      <div className="flex items-center justify-center w-full h-full rounded-md bg-ot-gray-800 text-ot-gray-700">
+                        <span className="text-xl font-bold">✕</span>
+                      </div>
                     )}
                   </div>
                 </td>
@@ -136,11 +140,7 @@ export function AdminShortsList({
       </div>
 
       {action === "edit" && hasSelectedMediaId ? (
-        <AdminShortsEditModal
-          mediaId={selectedMediaId}
-          onClose={handleClose}
-          onUpdate={() => handleClose()} // FIXME: 수정 api 붙인 뒤 수정
-        />
+        <AdminShortsEditModal mediaId={selectedMediaId} onClose={handleClose} />
       ) : (
         hasSelectedMediaId && (
           <AdminShortsDetailModal

--- a/src/features/shorts-manage/AdminShortsList.tsx
+++ b/src/features/shorts-manage/AdminShortsList.tsx
@@ -81,18 +81,12 @@ export function AdminShortsList({
                 <td className="py-3">
                   <div className="relative aspect-5/7 max-w-12 w-full mx-auto">
                     {short.posterUrl ? (
-                      <>
-                        <Image
-                          src={short.posterUrl}
-                          alt={short.title}
-                          fill
-                          className="object-cover rounded-md"
-                        />
-                        <div
-                          className="w-full h-full rounded-md bg-ot-gray-800"
-                          aria-label="썸네일 없음"
-                        />
-                      </>
+                      <Image
+                        src={short.posterUrl}
+                        alt={short.title}
+                        fill
+                        className="object-cover rounded-md"
+                      />
                     ) : (
                       <div className="flex items-center justify-center w-full h-full rounded-md bg-ot-gray-800 text-ot-gray-700">
                         <span className="text-xl font-bold">✕</span>

--- a/src/features/shorts-manage/AdminShortsUploadModal.tsx
+++ b/src/features/shorts-manage/AdminShortsUploadModal.tsx
@@ -1,16 +1,21 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useIsMounted } from "@/shared/hooks";
+import { uploadFileToS3 } from "@/shared/lib";
 import { X } from "lucide-react";
-import { ContentListItem } from "@entities/video-contents/apis";
-import { AdminOriginalContentsDropdown } from "@entities/video-contents/components";
+import { OriginMediaItem } from "@entities/originMedia/apis";
+import { AdminOriginalContentsDropdown } from "@entities/originMedia/components";
+import { UploadShortsRequest } from "@entities/shorts/apis";
+import { useUploadShorts } from "@entities/shorts/hooks";
 import {
   AdminFileUpload,
   AdminPosterUpload,
   AdminPublicStatus,
   AdminTextInput,
   CommonButton,
+  ConfirmModal,
   PosterState,
 } from "@shared/components";
 import { VideoFileMeta } from "@shared/types";
@@ -20,36 +25,31 @@ interface AdminShortsUploadModalProps {
   onClose: () => void;
 }
 
-const ORIGINAL_LIST = [
-  "더글로리",
-  "선재 업고 튀어",
-  "흑백 요리사 시즌1",
-  "흑백 요리사 시즌2",
-  "대탈출 1",
-  "대탈출 2",
-  "대탈출 3",
-  "대탈출 4",
-  "대탈출 5",
-];
 export function AdminShortsUploadModal({
   open,
   onClose,
 }: AdminShortsUploadModalProps) {
-  const [mounted, setMounted] = useState<boolean>(false);
+  const mounted = useIsMounted();
+  const { mutateAsync: uploadShorts, isPending } = useUploadShorts();
 
   const [title, setTitle] = useState<string>("");
   const [description, setDescription] = useState<string>("");
   const [isPublic, setIsPublic] = useState<boolean>(false);
   const [videoFile, setVideoFile] = useState<VideoFileMeta | null>(null);
   const [selectedOriginal, setSelectedOriginal] =
-    useState<ContentListItem | null>(null);
+    useState<OriginMediaItem | null>(null);
   const [poster, setPoster] = useState<PosterState>({
     posterUrl: null,
-    thumbnailUrl: null,
   });
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+  const [uploadError, setUploadError] = useState<boolean>(false);
+
+  const formRef = useRef<HTMLFormElement>(null);
+  const isFormValid =
+    !!videoFile &&
+    !!title.trim() &&
+    !!description.trim() &&
+    !!poster.posterFile &&
+    !!selectedOriginal;
 
   useEffect(() => {
     if (!open) return;
@@ -69,84 +69,154 @@ export function AdminShortsUploadModal({
 
   if (!mounted || !open) return null;
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log("숏폼 업로드 처리 로직");
+    if (!videoFile || !selectedOriginal) return;
+
+    const body: UploadShortsRequest = {
+      title: title,
+      description: description,
+      mediaType: selectedOriginal.mediaType,
+      publicStatus: isPublic ? "PUBLIC" : "PRIVATE",
+      originId: selectedOriginal.originId,
+      duration: videoFile.duration,
+      videoSize: videoFile.size,
+      ...(poster.posterFile && { posterFileName: poster.posterFile.name }),
+      ...(poster.thumbnailFile && {
+        thumbnailFileName: poster.thumbnailFile.name,
+      }),
+      ...(videoFile.name && { originFileName: videoFile.name }),
+    };
+    try {
+      // throw new Error("강제 에러 테스트"); // error 테스트 시 주석 해제
+      const { posterUploadUrl, originUploadUrl } = await uploadShorts(body);
+
+      // S3 직접 업로드 (병렬)
+      await Promise.all([
+        poster.posterFile
+          ? uploadFileToS3(posterUploadUrl, poster.posterFile)
+          : Promise.resolve(),
+        videoFile.file
+          ? uploadFileToS3(originUploadUrl, videoFile.file)
+          : Promise.resolve(),
+      ]);
+      onClose();
+    } catch (error) {
+      console.error("업로드 실패:", error);
+      setUploadError(true);
+    }
   };
 
-  return createPortal(
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={onClose}
-    >
-      <div
-        className="relative w-218 bg-ot-text rounded-lg py-6 px-8 shadow-xl overflow-y-auto max-h-[90vh]"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* 헤더 */}
-        <div className="relative mb-8 text-ot-background">
-          <p className="text-2xl font-bold">숏폼 업로드</p>
-          <button
-            onClick={onClose}
-            className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"
-          >
-            <X size={22} />
-          </button>
-        </div>
+  const handleClose = () => {
+    if (isPending) return;
+    onClose();
+  };
 
-        <form
-          className="flex flex-col gap-6 text-ot-background"
-          onSubmit={handleSubmit}
+  const handleRetry = () => {
+    setUploadError(false);
+    requestAnimationFrame(() => {
+      formRef.current?.requestSubmit();
+    });
+  };
+
+  return (
+    <>
+      {createPortal(
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={handleClose}
         >
-          <AdminFileUpload value={videoFile} onChange={setVideoFile} />
-
-          <AdminTextInput
-            label="제목"
-            placeholder="숏폼 제목을 입력하세요"
-            value={title}
-            onChange={setTitle}
-          />
-
-          <AdminTextInput
-            label="설명"
-            placeholder="숏폼 설명을 입력하세요"
-            multiline
-            value={description}
-            onChange={setDescription}
-          />
-
-          {/* 원본콘텐츠·공개여부 + 포스터 */}
-          <div className="grid grid-cols-2 gap-12">
-            {/* 좌측 */}
-            <div className="flex flex-col gap-6">
-              <AdminOriginalContentsDropdown
-                value={selectedOriginal}
-                onChange={setSelectedOriginal}
-              />
-              <AdminPublicStatus isPublic={isPublic} onChange={setIsPublic} />
+          <div
+            className="relative w-218 bg-ot-text rounded-lg py-6 px-8 shadow-xl overflow-y-auto max-h-[90vh]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* 헤더 */}
+            <div className="relative mb-8 text-ot-background">
+              <p className="text-2xl font-bold">숏폼 업로드</p>
+              <button
+                onClick={handleClose}
+                className="absolute top-0 right-0 text-ot-background hover:text-ot-gray-600 transition-colors cursor-pointer"
+              >
+                <X size={22} />
+              </button>
             </div>
 
-            {/* 우측 */}
-            <AdminPosterUpload value={poster} onChange={setPoster} isShorts />
-          </div>
-
-          {/* 버튼 */}
-          <div className="grid grid-cols-2 gap-4">
-            <CommonButton
-              type="button"
-              onClick={onClose}
-              className="py-3 font-semibold"
-              variant="outline"
+            <form
+              ref={formRef}
+              className="flex flex-col gap-6 text-ot-background"
+              onSubmit={handleSubmit}
             >
-              취소
-            </CommonButton>
-            <CommonButton type="submit" className="py-3 font-semibold">
-              업로드 시작
-            </CommonButton>
+              <AdminFileUpload value={videoFile} onChange={setVideoFile} />
+
+              <AdminTextInput
+                label="제목"
+                placeholder="숏폼 제목을 입력하세요"
+                value={title}
+                onChange={setTitle}
+              />
+
+              <AdminTextInput
+                label="설명"
+                placeholder="숏폼 설명을 입력하세요"
+                multiline
+                value={description}
+                onChange={setDescription}
+              />
+
+              {/* 원본콘텐츠·공개여부 + 포스터 */}
+              <div className="grid grid-cols-2 gap-12">
+                {/* 좌측 */}
+                <div className="flex flex-col gap-6">
+                  <AdminOriginalContentsDropdown
+                    value={selectedOriginal}
+                    onChange={setSelectedOriginal}
+                  />
+                  <AdminPublicStatus
+                    isPublic={isPublic}
+                    onChange={setIsPublic}
+                  />
+                </div>
+                {/* 우측 */}
+                <AdminPosterUpload
+                  value={poster}
+                  onChange={setPoster}
+                  isShorts
+                />
+              </div>
+
+              {/* 버튼 */}
+              <div className="grid grid-cols-2 gap-4">
+                <CommonButton
+                  type="button"
+                  onClick={handleClose}
+                  className="py-3 font-semibold"
+                  variant="outline"
+                  disabled={isPending}
+                >
+                  취소
+                </CommonButton>
+                <CommonButton
+                  type="submit"
+                  className="py-3 font-semibold"
+                  disabled={isPending || !isFormValid}
+                >
+                  {isPending ? "업로드 중..." : "업로드 시작"}
+                </CommonButton>
+              </div>
+            </form>
           </div>
-        </form>
-      </div>
-    </div>,
-    document.body,
+        </div>,
+        document.body,
+      )}
+      <ConfirmModal
+        isOpen={uploadError}
+        message={"업로드에 실패했습니다.\n다시 시도하시겠습니까?"}
+        confirmText="재시도"
+        cancelText="취소"
+        onConfirm={handleRetry}
+        onClose={() => setUploadError(false)}
+        disabled={isPending}
+      />
+    </>
   );
 }

--- a/src/features/shorts-manage/AdminShortsUploadModal.tsx
+++ b/src/features/shorts-manage/AdminShortsUploadModal.tsx
@@ -74,18 +74,16 @@ export function AdminShortsUploadModal({
     if (!videoFile || !selectedOriginal) return;
 
     const body: UploadShortsRequest = {
-      title: title,
-      description: description,
+      title,
+      description,
       mediaType: selectedOriginal.mediaType,
       publicStatus: isPublic ? "PUBLIC" : "PRIVATE",
       originId: selectedOriginal.originId,
       duration: videoFile.duration,
       videoSize: videoFile.size,
-      ...(poster.posterFile && { posterFileName: poster.posterFile.name }),
-      ...(poster.thumbnailFile && {
-        thumbnailFileName: poster.thumbnailFile.name,
-      }),
-      ...(videoFile.name && { originFileName: videoFile.name }),
+      posterFileName: poster.posterFile?.name,
+      thumbnailFileName: poster.thumbnailFile?.name,
+      originFileName: videoFile!.name,
     };
     try {
       // throw new Error("강제 에러 테스트"); // error 테스트 시 주석 해제


### PR DESCRIPTION
## 📝 작업 내용

> **백오피스 숏폼 업로드, 수정 API 연동**
> - 콘텐츠와 마찬가지로 숏폼 업로드는 잘 되나, 수정 쪽에서 처음 값을 불러올 때, 원본콘텐츠 id (`originId`)가 상세조회 응답값에 포함되어 있지 않아서 원본 콘텐츠 값을 못 불러오고 있습니다. 백엔드에 수정 요청한 상황으로 수정 다 되면 originId을 불러와서 원본콘텐츠 값이 잘 담기는지 확인해보도록 하겠습니다.
> - 콘텐츠 업로드/수정 API와 동일한 구조입니다.

## 📷 스크린샷

- 숏폼 업로드

https://github.com/user-attachments/assets/c677cbfe-c117-410b-8aaa-74376dd55f6a

- 숏폼 수정

https://github.com/user-attachments/assets/442fcd00-66c2-4d01-ae0c-74227e125a91


## 🖥️ 주요 코드 설명


## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #23 

## 💬 리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 원본 미디어 선택 드롭다운(검색 + 무한스크롤) 추가
  * 숏폼 업로드·수정용 업로드/수정 API 및 관련 업로드 훅 추가
  * 업로드 모달 및 편집 모달을 포털 기반 폼으로 개선, 재시도 확인 모달 추가

* **버그 수정**
  * 썸네일 렌더링 개선(이미지 표시 및 누락 시 명확한 플레이스홀더)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->