### PR TITLE
[OT-241] [FEAT]: 콘텐츠 업로드, 수정 모달 시리즈 제목 조회 API 연동

### DIFF
--- a/src/entities/series/components/AdminSeriesDetailModal.tsx
+++ b/src/entities/series/components/AdminSeriesDetailModal.tsx
@@ -59,23 +59,35 @@ export function AdminSeriesDetailModal({
                 <div className="flex flex-col gap-1">
                   <p className="text-sm text-ot-background">세로 (5:7)</p>
                   <div className="relative w-60 aspect-5/7 rounded-lg overflow-hidden">
-                    {/* <Image
-                      src={series.posterUrl}
-                      alt={`${series.title} 세로 썸네일`}
-                      fill
-                      className="object-cover"
-                    /> */}
+                    {series.posterUrl ? (
+                      <Image
+                        src={series.posterUrl}
+                        alt={series.title}
+                        fill
+                        className="object-cover rounded-md"
+                      />
+                    ) : (
+                      <div className="flex items-center justify-center w-full h-full rounded-md bg-ot-gray-800 text-ot-gray-700">
+                        <span className="text-xl font-bold">✕</span>
+                      </div>
+                    )}
                   </div>
                 </div>
                 <div className="flex flex-col gap-1">
                   <p className="text-sm text-ot-background">가로 (4:3)</p>
                   <div className="relative w-113 aspect-4/3 rounded-lg overflow-hidden">
-                    {/* <Image
-                      src={series.thumbnailUrl}
-                      alt={`${series.title} 가로 썸네일`}
-                      fill
-                      className="object-cover"
-                    /> */}
+                    {series.thumbnailUrl ? (
+                      <Image
+                        src={series.thumbnailUrl}
+                        alt={series.title}
+                        fill
+                        className="object-cover rounded-md"
+                      />
+                    ) : (
+                      <div className="flex items-center justify-center w-full h-full rounded-md bg-ot-gray-800 text-ot-gray-700">
+                        <span className="text-xl font-bold">✕</span>
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>
@@ -93,9 +105,7 @@ export function AdminSeriesDetailModal({
 
             {/* 설명 */}
             <section className="flex flex-col gap-1">
-              <p className="text-base text-ot-background font-semibold">
-                설명
-              </p>
+              <p className="text-base text-ot-background font-semibold">설명</p>
               <p className="text-sm text-ot-background leading-relaxed">
                 {series.description}
               </p>

--- a/src/entities/series/components/AdminSeriesDropdown.tsx
+++ b/src/entities/series/components/AdminSeriesDropdown.tsx
@@ -1,43 +1,60 @@
 "use client";
 // 콘텐츠 모달 내 시리즈 드롭다운
 import { useRef, useState } from "react";
-import { ChevronDown, Search } from "lucide-react";
-import { SeriesListItem } from "@entities/series/apis";
-import { useInfiniteSeriesList } from "@entities/series/hooks";
+import { ChevronDown, Loader2, Search } from "lucide-react";
+import { SeriesTitleItem } from "@entities/video-contents/apis";
+import { useInfiniteSeriesTitle } from "@entities/video-contents/hooks";
 import { useOutsideClick } from "@shared/hooks";
 import { cn } from "@shared/utils";
 
 export interface AdminSeriesDropdownProps {
   value: number | null;
-  onChange: (seriesId: number | null, item: SeriesListItem | null) => void;
+  selectedTitle?: string | null;
+  onChange: (seriesId: number | null, item: SeriesTitleItem | null) => void;
   disabled?: boolean;
 }
 
 export function AdminSeriesDropdown({
   value,
+  selectedTitle: initialTitle,
   onChange,
   disabled = false,
 }: AdminSeriesDropdownProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [searchWord, setSearchWord] = useState<string>("");
+  const [inputValue, setInputValue] = useState<string>("");
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const searchInputRef = useRef<HTMLInputElement>(null);
 
-  // FIXME: 추후 시리즈 제목 조회 api로 연동 필요 (백엔드 수정 완료 시)
-  const { seriesList, observerRef, isFetchingNextPage } = useInfiniteSeriesList(
-    { searchWord },
-  );
+  const { seriesTitles, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useInfiniteSeriesTitle({ searchWord });
 
   useOutsideClick(dropdownRef, () => setIsOpen(false), isOpen);
 
-  const handleSelect = (item: SeriesListItem | null) => {
-    onChange(item ? item.mediaId : null, item);
+  const handleSelect = (item: SeriesTitleItem | null) => {
+    onChange(item ? item.seriesId : null, item);
     setIsOpen(false);
     setSearchWord("");
-    if (searchInputRef.current) searchInputRef.current.value = "";
+    setInputValue("");
   };
 
-  const selectedTitle = seriesList.find((s) => s.mediaId === value)?.title;
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      setSearchWord(inputValue);
+    }
+  };
+
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
+    if (scrollHeight - scrollTop <= clientHeight + 10) {
+      if (hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
+    }
+  };
+
+  const displayTitle =
+    initialTitle ?? seriesTitles.find((s) => s.seriesId === value)?.title;
 
   return (
     <div>
@@ -50,6 +67,7 @@ export function AdminSeriesDropdown({
           onClick={() => {
             setIsOpen((prev) => !prev);
             setSearchWord("");
+            setInputValue("");
           }}
           className={cn(
             "w-full flex items-center justify-between border rounded-lg py-3 px-4 text-sm text-left transition-colors",
@@ -61,7 +79,7 @@ export function AdminSeriesDropdown({
           <span
             className={cn(value ? "text-ot-background" : "text-ot-gray-600")}
           >
-            {selectedTitle ?? "시리즈 선택"}
+            {displayTitle ?? "시리즈 선택"}
           </span>
 
           <ChevronDown
@@ -79,62 +97,65 @@ export function AdminSeriesDropdown({
               <input
                 type="text"
                 autoFocus
-                ref={searchInputRef}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    setSearchWord(searchInputRef.current?.value ?? "");
-                  }
-                }}
-                placeholder="시리즈 검색"
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="시리즈 검색 (Enter)"
                 className="flex-1 text-sm placeholder:text-ot-gray-600 outline-none text-ot-background"
               />
-              <Search size={15} className="text-ot-gray-600 shrink-0" />
-            </div>
-
-            <div className="max-h-48 overflow-y-auto">
               <button
                 type="button"
-                onClick={() => handleSelect(null)}
-                className={cn(
-                  "w-full text-left px-4 py-3 text-sm transition-colors cursor-pointer",
-                  value === null
-                    ? "bg-ot-primary-gradient text-ot-text"
-                    : "text-ot-background hover:bg-ot-gray-200",
-                )}
+                onClick={() => setSearchWord(inputValue)}
+                className="cursor-pointer"
               >
-                시리즈 없음
+                <Search size={15} className="text-ot-gray-600 shrink-0" />
               </button>
+            </div>
 
-              {seriesList.length > 0 ? (
-                seriesList.map((series) => (
+            <div className="max-h-48 overflow-y-auto" onScroll={handleScroll}>
+              {seriesTitles.length > 0 ? (
+                <>
                   <button
                     type="button"
-                    key={series.mediaId}
-                    onClick={() => handleSelect(series)}
+                    onClick={() => handleSelect(null)}
                     className={cn(
                       "w-full text-left px-4 py-3 text-sm transition-colors cursor-pointer",
-                      value === series.mediaId
+                      value === null
                         ? "bg-ot-primary-gradient text-ot-text"
                         : "text-ot-background hover:bg-ot-gray-200",
                     )}
                   >
-                    {series.title}
+                    시리즈 없음
                   </button>
-                ))
+                  {seriesTitles.map((series) => (
+                    <button
+                      type="button"
+                      key={series.seriesId}
+                      onClick={() => handleSelect(series)}
+                      className={cn(
+                        "w-full text-left px-4 py-3 text-sm transition-colors cursor-pointer",
+                        value === series.seriesId
+                          ? "bg-ot-primary-gradient text-ot-text"
+                          : "text-ot-background hover:bg-ot-gray-200",
+                      )}
+                    >
+                      {series.title}
+                    </button>
+                  ))}
+                  <div className="py-1 flex justify-center">
+                    {isFetchingNextPage && (
+                      <Loader2
+                        className="animate-spin text-ot-placeholder"
+                        size={20}
+                      />
+                    )}
+                  </div>
+                </>
               ) : (
                 <p className="px-4 py-3 text-sm text-ot-gray-600">
                   검색 결과가 없습니다
                 </p>
               )}
-
-              <div ref={observerRef} className="py-1">
-                {isFetchingNextPage && (
-                  <p className="text-center text-xs text-ot-gray-600 py-1">
-                    불러오는 중...
-                  </p>
-                )}
-              </div>
             </div>
           </div>
         )}

--- a/src/entities/video-contents/apis/getSeriesTitleApi.ts
+++ b/src/entities/video-contents/apis/getSeriesTitleApi.ts
@@ -1,0 +1,30 @@
+import { api } from "@/shared/api";
+import { ApiResponse, BasePaginationParams, PageInfo } from "@shared/types";
+
+export interface SeriesTitleItem {
+  seriesId: number;
+  title: string;
+  categoryName: string;
+  tagNameList: string[];
+}
+
+export interface SeriesTitleResponse {
+  pageInfo: PageInfo;
+  dataList: SeriesTitleItem[];
+}
+
+export interface GetSeriesTitleParams extends BasePaginationParams {
+  page: number;
+  size: number;
+  searchWord?: string;
+}
+
+export const getSeriesTitleApi = async (params: GetSeriesTitleParams) => {
+  const res = await api.get<ApiResponse<SeriesTitleResponse>>(
+    "/admin/series/titles",
+    {
+      params,
+    },
+  );
+  return res.data.data;
+};

--- a/src/entities/video-contents/apis/getVideoContentsApi.ts
+++ b/src/entities/video-contents/apis/getVideoContentsApi.ts
@@ -38,6 +38,7 @@ export const getContentListApi = async (params: GetContentListParams) => {
 
 export interface ContentDetailResponse {
   contentsId: number;
+  seriesId: number;
   posterUrl: string;
   thumbnailUrl: string;
   title: string;

--- a/src/entities/video-contents/apis/getVideoContentsApi.ts
+++ b/src/entities/video-contents/apis/getVideoContentsApi.ts
@@ -38,7 +38,7 @@ export const getContentListApi = async (params: GetContentListParams) => {
 
 export interface ContentDetailResponse {
   contentsId: number;
-  seriesId: number;
+  seriesId: number | null;
   posterUrl: string;
   thumbnailUrl: string;
   title: string;

--- a/src/entities/video-contents/apis/index.ts
+++ b/src/entities/video-contents/apis/index.ts
@@ -1,2 +1,3 @@
 export * from "./getVideoContentsApi";
 export * from "./videoContentsApi";
+export * from "./getSeriesTitleApi";

--- a/src/entities/video-contents/hooks/index.ts
+++ b/src/entities/video-contents/hooks/index.ts
@@ -3,3 +3,5 @@ export {
   useUploadVideoContents,
   useUpdateVideoContents,
 } from "./useUploadVideoContents";
+
+export { useInfiniteSeriesTitle } from "./useSeriesTitle";

--- a/src/entities/video-contents/hooks/useSeriesTitle.ts
+++ b/src/entities/video-contents/hooks/useSeriesTitle.ts
@@ -1,0 +1,41 @@
+import { useInfiniteScroll } from "@/shared/hooks";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import {
+  SeriesTitleItem,
+  getSeriesTitleApi,
+} from "@entities/video-contents/apis";
+
+interface UseInfiniteSeriesTitleParams {
+  size?: number;
+  searchWord?: string;
+}
+export const useInfiniteSeriesTitle = ({
+  size = 10,
+  searchWord,
+}: UseInfiniteSeriesTitleParams) => {
+  const query = useInfiniteQuery({
+    queryKey: ["series", "title", { size, searchWord }],
+    queryFn: ({ pageParam = 0 }) =>
+      getSeriesTitleApi({
+        page: pageParam as number,
+        size,
+        searchWord: searchWord || undefined,
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      const { currentPage, totalPage } = lastPage.pageInfo;
+      return currentPage + 1 < totalPage ? currentPage + 1 : undefined;
+    },
+  });
+
+  const { observerRef } = useInfiniteScroll({
+    hasNextPage: query.hasNextPage,
+    isFetchingNextPage: query.isFetchingNextPage,
+    fetchNextPage: query.fetchNextPage,
+  });
+
+  const seriesTitles: SeriesTitleItem[] =
+    query.data?.pages.flatMap((page) => page.dataList) ?? [];
+
+  return { ...query, seriesTitles, observerRef };
+};

--- a/src/features/series-manage/components/AdminSeriesContents.tsx
+++ b/src/features/series-manage/components/AdminSeriesContents.tsx
@@ -1,14 +1,15 @@
 "use client";
 
+import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Edit, Loader2 } from "lucide-react";
 import { AdminSeriesEditModal } from "@features/series-manage/components";
-import { CategoryBadge } from "@entities/category/components/CategoryBadge";
+import { CategoryBadge } from "@entities/category/components";
 import { useCategories } from "@entities/category/hooks";
 import { AdminSeriesDetailModal } from "@entities/series/components";
-import { TagBadge } from "@entities/tag/components/TagBagde";
-import { AdminPublicBadge } from "@shared/components";
 import { useInfiniteSeriesList } from "@entities/series/hooks";
+import { TagBadge } from "@entities/tag/components";
+import { AdminPublicBadge } from "@shared/components";
 
 interface AdminSeriesContentsProps {
   searchWord?: string;
@@ -21,7 +22,10 @@ export function AdminSeriesContents({ searchWord }: AdminSeriesContentsProps) {
   const { data: categories } = useCategories();
 
   const getCategoryId = (categoryName: string): number | null => {
-    return categories?.find((c) => c.categoryName === categoryName)?.categoryId ?? null;
+    return (
+      categories?.find((c) => c.categoryName === categoryName)?.categoryId ??
+      null
+    );
   };
 
   const router = useRouter();
@@ -88,21 +92,18 @@ export function AdminSeriesContents({ searchWord }: AdminSeriesContentsProps) {
                 >
                   <td className="py-3">
                     <div className="relative aspect-5/7 max-w-12 w-full mx-auto">
-                      {content.posterUrl ? (
-                      <div>{content.posterUrl} 예시</div>
-                    ) : (
-                      // TODO: 썸네일 넣어야 함
-                      // <Image
-                      //   src={content.posterUrl}
-                      //   alt={content.title}
-                      //   fill
-                      //   className="object-cover rounded-md"
-                      // />
-                      <div
-                        className="w-full h-full rounded-md bg-ot-gray-800"
-                        aria-label="썸네일 없음"
-                      />
-                    )}
+                      {content.thumbnailUrl ? (
+                        <Image
+                          src={content.thumbnailUrl}
+                          alt={content.title}
+                          fill
+                          className="object-cover rounded-md"
+                        />
+                      ) : (
+                        <div className="flex items-center justify-center w-full h-full rounded-md bg-ot-gray-800 text-ot-gray-700">
+                          <span className="text-xl font-bold">✕</span>
+                        </div>
+                      )}
                     </div>
                   </td>
 
@@ -175,7 +176,10 @@ export function AdminSeriesContents({ searchWord }: AdminSeriesContentsProps) {
         />
       ) : (
         hasSelectedMediaId && (
-          <AdminSeriesDetailModal mediaId={selectedMediaId!} onClose={handleClose} />
+          <AdminSeriesDetailModal
+            mediaId={selectedMediaId!}
+            onClose={handleClose}
+          />
         )
       )}
     </>

--- a/src/features/video-contents-manage/components/AdminVideoContentsEditModal.tsx
+++ b/src/features/video-contents-manage/components/AdminVideoContentsEditModal.tsx
@@ -6,11 +6,10 @@ import { X } from "lucide-react";
 import { AdminContentTypeSelector } from "@features/video-contents-manage/components";
 import { AdminCategoryDropdown } from "@entities/category/components";
 import { useCategories } from "@entities/category/hooks";
-import { SeriesListItem } from "@entities/series/apis";
 import { AdminSeriesDropdown } from "@entities/series/components";
 import { AdminTagDropdown } from "@entities/tag/components";
 import {
-  ContentDetailResponse,
+  SeriesTitleItem,
   UploadVideoRequest,
 } from "@entities/video-contents/apis";
 import { useContentDetail } from "@entities/video-contents/hooks";
@@ -29,13 +28,11 @@ import { ContentType, PublicStatus } from "@shared/types";
 interface AdminVideoContentsEditModalProps {
   mediaId: number;
   onClose: () => void;
-  onUpdate: (updated: ContentDetailResponse) => void;
 }
 
 export function AdminVideoContentsEditModal({
   mediaId,
   onClose,
-  onUpdate,
 }: AdminVideoContentsEditModalProps) {
   const { data, isLoading, isError } = useContentDetail(mediaId);
   const { data: categories } = useCategories();
@@ -48,8 +45,12 @@ export function AdminVideoContentsEditModal({
   const [cast, setCast] = useState<string>("");
   const [isPublic, setIsPublic] = useState<PublicStatus>("PUBLIC");
   const [selectedSeries, setSelectedSeries] = useState<number | null>(null);
+  const [selectedSeriesTitle, setSelectedSeriesTitle] = useState<string | null>(
+    null,
+  );
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
+  const [pendingTagNames, setPendingTagNames] = useState<string[] | null>(null);
   const [poster, setPoster] = useState<PosterState>({
     posterUrl: null,
     thumbnailUrl: null,
@@ -58,7 +59,6 @@ export function AdminVideoContentsEditModal({
   const [uploadError, setUploadError] = useState<boolean>(false);
 
   const { data: tagList } = useTagsByCategory(selectedCategory);
-  const tags = tagList ?? [];
   const formRef = useRef<HTMLFormElement>(null);
 
   useEffect(() => {
@@ -68,7 +68,8 @@ export function AdminVideoContentsEditModal({
     setCast(data.actors);
     setIsPublic(data.publicStatus);
     setContentType(data.seriesTitle ? "시리즈" : "단편");
-    setSelectedSeries(null); // TODO: API 응답에 seriesId 추가되면 setSelectedSeries(data.seriesId ?? null) 로 교체
+    setSelectedSeries(data.seriesId ?? null);
+    setSelectedSeriesTitle(data.seriesTitle ?? null);
 
     const categoryId =
       categories.find((c) => c.categoryName === data.categoryName)
@@ -82,7 +83,6 @@ export function AdminVideoContentsEditModal({
     setIsInitialized(true);
   }, [data, isInitialized, categories]);
 
-  // tagList가 로드된 후 태그 초기화 (최초 1회만)
   useEffect(() => {
     if (!data || !tagList || isTagInitialized) return;
     setSelectedTags(
@@ -92,6 +92,17 @@ export function AdminVideoContentsEditModal({
     );
     setIsTagInitialized(true);
   }, [data, tagList, isTagInitialized]);
+
+  // pendingTagNames 있으면 tagList 로드 후 세팅
+  useEffect(() => {
+    if (!pendingTagNames || !tagList) return;
+    setSelectedTags(
+      pendingTagNames
+        .map((name) => tagList.find((t) => t.name === name)?.tagId)
+        .filter((id): id is number => id !== undefined),
+    );
+    setPendingTagNames(null);
+  }, [pendingTagNames, tagList]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -114,24 +125,41 @@ export function AdminVideoContentsEditModal({
 
   const handleContentTypeChange = (type: ContentType) => {
     setContentType(type);
-    if (type === "단편") setSelectedSeries(null);
+    if (type === "단편") {
+      setSelectedSeries(null);
+      setSelectedSeriesTitle(null);
+      setSelectedCategory(null);
+      setSelectedTags([]);
+      setPendingTagNames(null);
+    }
   };
 
   const handleCategoryChange = (category: number | null) => {
     setSelectedCategory(category);
     setSelectedTags([]);
+    setPendingTagNames(null);
   };
 
   const handleSeriesChange = (
     seriesId: number | null,
-    item: SeriesListItem | null,
+    item: SeriesTitleItem | null,
   ) => {
     setSelectedSeries(seriesId);
-    // TODO: API에 seriesId 기반 categoryId, tagIdList 추가되면 자동 세팅
-    // if (item) {
-    //   setSelectedCategory(item.categoryId);
-    //   setSelectedTags(item.tagIdList);
-    // }
+    setSelectedSeriesTitle(item?.title ?? null);
+
+    if (!item) {
+      setSelectedCategory(null);
+      setSelectedTags([]);
+      setPendingTagNames(null);
+      return;
+    }
+
+    const categoryId =
+      categories?.find((c) => c.categoryName === item.categoryName)
+        ?.categoryId ?? null;
+    setSelectedCategory(categoryId);
+    setSelectedTags([]);
+    setPendingTagNames(item.tagNameList);
   };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -176,24 +204,6 @@ export function AdminVideoContentsEditModal({
         setUploadError(true);
         return;
       }
-
-      const tagNameList = tags
-        .filter((t) => selectedTags.includes(t.tagId))
-        .map((t) => t.name);
-
-      onUpdate({
-        ...data,
-        seriesTitle: selectedSeries ? String(selectedSeries) : null,
-        title,
-        description,
-        categoryName: data.categoryName,
-        tagNameList,
-        publicStatus: isPublic,
-        actors: cast,
-        posterUrl: poster.posterUrl ?? data.posterUrl,
-        thumbnailUrl: poster.thumbnailUrl ?? data.thumbnailUrl,
-      });
-
       onClose();
     } catch (error) {
       console.error("수정 실패:", error);
@@ -264,6 +274,7 @@ export function AdminVideoContentsEditModal({
               <div className="grid grid-cols-2 gap-6">
                 <AdminSeriesDropdown
                   value={selectedSeries}
+                  selectedTitle={selectedSeriesTitle}
                   onChange={handleSeriesChange}
                   disabled={contentType === "단편"}
                 />

--- a/src/features/video-contents-manage/components/AdminVideoContentsList.tsx
+++ b/src/features/video-contents-manage/components/AdminVideoContentsList.tsx
@@ -143,7 +143,6 @@ export function AdminVideoContentsList({
         <AdminVideoContentsEditModal
           mediaId={selectedMediaId}
           onClose={handleClose}
-          onUpdate={() => handleClose()} // FIXME: 수정 api 붙인 뒤 수정
         />
       ) : (
         hasSelectedMediaId && (

--- a/src/features/video-contents-manage/components/AdminVideoContentsUploadModal.tsx
+++ b/src/features/video-contents-manage/components/AdminVideoContentsUploadModal.tsx
@@ -2,13 +2,17 @@
 
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { SeriesListItem } from "@/entities/series/apis";
 import { X } from "lucide-react";
 import { AdminContentTypeSelector } from "@features/video-contents-manage/components";
 import { AdminCategoryDropdown } from "@entities/category/components";
+import { useCategories } from "@entities/category/hooks";
 import { AdminSeriesDropdown } from "@entities/series/components";
+import { useTagsByCategory } from "@entities/statistics/hooks";
 import { AdminTagDropdown } from "@entities/tag/components";
-import { UploadVideoRequest } from "@entities/video-contents/apis";
+import {
+  SeriesTitleItem,
+  UploadVideoRequest,
+} from "@entities/video-contents/apis";
 import { useUploadVideoContents } from "@entities/video-contents/hooks";
 import {
   AdminFileUpload,
@@ -48,15 +52,17 @@ export function AdminVideoContentsUploadModal({
 
 function ModalInner({ onClose }: { onClose: () => void }) {
   const { mutateAsync: uploadVideo, isPending } = useUploadVideoContents();
+  const { data: categories } = useCategories();
 
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [cast, setCast] = useState("");
-  const [isPublic, setIsPublic] = useState(false);
+  const [title, setTitle] = useState<string>("");
+  const [description, setDescription] = useState<string>("");
+  const [cast, setCast] = useState<string>("");
+  const [isPublic, setIsPublic] = useState<boolean>(false);
   const [videoFile, setVideoFile] = useState<VideoFileMeta | null>(null);
   const [selectedSeries, setSelectedSeries] = useState<number | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
+  const [pendingTagNames, setPendingTagNames] = useState<string[] | null>(null);
   const [poster, setPoster] = useState<PosterState>({
     posterUrl: null,
     thumbnailUrl: null,
@@ -64,7 +70,19 @@ function ModalInner({ onClose }: { onClose: () => void }) {
   const [contentType, setContentType] = useState<ContentType>("단편");
   const [uploadError, setUploadError] = useState<boolean>(false);
 
+  const { data: tagList } = useTagsByCategory(selectedCategory);
   const formRef = useRef<HTMLFormElement>(null);
+
+  // pendingTagNames 있으면 tagList 로드 후 세팅
+  useEffect(() => {
+    if (!pendingTagNames || !tagList) return;
+    setSelectedTags(
+      pendingTagNames
+        .map((name) => tagList.find((t) => t.name === name)?.tagId)
+        .filter((id): id is number => id !== undefined),
+    );
+    setPendingTagNames(null);
+  }, [pendingTagNames, tagList]);
 
   const isFormValid =
     !!videoFile &&
@@ -85,20 +103,39 @@ function ModalInner({ onClose }: { onClose: () => void }) {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [onClose]);
 
+  const handleContentTypeChange = (type: ContentType) => {
+    setContentType(type);
+    if (type === "단편") {
+      setSelectedSeries(null);
+      setSelectedCategory(null);
+      setSelectedTags([]);
+      setPendingTagNames(null);
+    }
+  };
+
   const handleSeriesChange = (
     seriesId: number | null,
-    item: SeriesListItem | null,
+    item: SeriesTitleItem | null,
   ) => {
     setSelectedSeries(seriesId);
     if (!item) {
       setSelectedCategory(null);
       setSelectedTags([]);
+      setPendingTagNames(null);
+      return;
     }
+    const categoryId =
+      categories?.find((c) => c.categoryName === item.categoryName)
+        ?.categoryId ?? null;
+    setSelectedCategory(categoryId);
+    setSelectedTags([]);
+    setPendingTagNames(item.tagNameList);
   };
 
   const handleCategoryChange = (category: number | null) => {
     setSelectedCategory(category);
     setSelectedTags([]);
+    setPendingTagNames(null);
   };
 
   const handleClose = () => {
@@ -145,8 +182,6 @@ function ModalInner({ onClose }: { onClose: () => void }) {
           : Promise.resolve(),
       ]);
 
-      console.log("S3 업로드 완료");
-      // 3. 완료 후 모달 닫기 (isPending 타이밍 이슈로 onClose 직접 호출)
       onClose();
     } catch (error) {
       console.error("업로드 실패:", error);
@@ -190,7 +225,7 @@ function ModalInner({ onClose }: { onClose: () => void }) {
             >
               <AdminContentTypeSelector
                 value={contentType}
-                onChange={setContentType}
+                onChange={handleContentTypeChange}
               />
               <AdminFileUpload value={videoFile} onChange={setVideoFile} />
 


### PR DESCRIPTION
## 📝 작업 내용

> - **콘텐츠** 업로드, 수정 모달 내에서 사용되는 시리즈 드롭다운 컴포넌트에 시리즈 제목 조회를 API 연동하였습니다.
>      - 드롭다운에서 시리즈 선택 시, 카테고리/태그가 자동 선택됩니다.
>      - 시리즈 선택된 상태에서 "단편"으로 contentsType 변경 시 시리즈 선택이 null이 됩니다.
> - **시리즈** 관리 리스트, 상세정보 모달에 Image 컴포넌트를 주석 해제하여 이미지가 잘 보이도록 수정했습니다.


## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. src에 이미지 url만 등록하면 됩니다. -->

| 구현 내용 |             시리즈 리스트              |      
| :-------: | :-------------------------: | 
|    GIF    | <img src = "https://github.com/user-attachments/assets/5e49755c-b68b-43b7-9522-09e4d3bc0f7e" width ="500"> | 

| 구현 내용 |             시리즈 상세정보              |      
| :-------: | :-------------------------: | 
|    GIF    | <img src = "https://github.com/user-attachments/assets/f03305db-cf8b-4891-9aa2-0eb64c84f2bf" width ="500"> | 

- 콘텐츠 업로드 - 시리즈 선택

https://github.com/user-attachments/assets/c3552e0e-9f79-42a1-99cb-aa64735ad0af

- 콘텐츠 수정 - 시리즈 선택

https://github.com/user-attachments/assets/676eeb26-d2f8-4a4c-ab9e-8e82929605ff



## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`AdminSeriesDropdown.tsx`

- 수정모달 내에서 시리즈 제목 조회 시, page=0에 포함된 seriesId의 제목만 렌더링이 되고, page= 1,2,.. 에 포함된 seriesId의 제목은 렌더링되지 않는 문제가 있었습니다.
- 이를 해결하기 위해 부모(콘텐츠 수정 모달)로부터 받은 initialTitle을 우선적으로 표시하고, 드롭다운에서 무한스크롤을 통해 스크롤을 내려서 해당 seriesId가 포함된 page가 로드되면, seriesTitles 목록에서 찾은 title로 자연스럽게 교체되도록 구현했습니다.

```ts
...
 const displayTitle =
    initialTitle ?? seriesTitles.find((s) => s.seriesId === value)?.title;
...
```
```
 <AdminSeriesDropdown
    value={selectedSeries}
    selectedTitle={selectedSeriesTitle} // 부모로부터 받은 seriesTitle
    onChange={handleSeriesChange}
    disabled={contentType === "단편"}
  />
```

## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #25 

## 💬 리뷰 요구사항

> 콘텐츠 업로드/수정 쪽은 완전 구현 마무리 됐습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 시리즈 선택에 검색 및 스크롤 기반 페이지네이션 추가
  * 시리즈 제목 기반 선택 지원 및 선택된 제목 표시 개선

* **버그 수정**
  * 이미지 누락 시 플레이스홀더로 표시하는 우아한 폴백 UI 적용
  * 썸네일에 둥근 모서리 및 대체 텍스트 개선

* **리팩토링**
  * 시리즈-카테고리-태그 자동 연동 및 태그 동기화 흐름 개선
  * 편집/업로드 모달의 상호작용: 업로드 후 모달이 자체적으로 닫히도록 변경 (외부 콜백 제거)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->