### PR TITLE
[OT-249] [FIX]: 시리즈 관리 수정 모달 에러 해결

### DIFF
--- a/src/features/series-manage/components/AdminSeriesEditModal.tsx
+++ b/src/features/series-manage/components/AdminSeriesEditModal.tsx
@@ -57,6 +57,10 @@ export function AdminSeriesEditModal({
     if (seriesDetail) {
       setDescription(seriesDetail.description);
       setCast(seriesDetail.actors);
+      setPoster({
+        posterUrl: seriesDetail.posterUrl,
+        thumbnailUrl: seriesDetail.thumbnailUrl,
+      });
     }
   }, [seriesDetail]);
 

--- a/src/features/series-manage/components/AdminSeriesEditModal.tsx
+++ b/src/features/series-manage/components/AdminSeriesEditModal.tsx
@@ -17,7 +17,7 @@ import {
 import { SeriesListItem } from "@entities/series/apis";
 import { useFixSeries } from "@entities/series/hooks";
 import { useSeriesDetail } from "@entities/series/hooks";
-import { TAGS } from "@shared/types";
+import { useTagsByCategory } from "@entities/statistics/hooks";
 import { uploadFileToS3 } from "@shared/lib";
 
 interface AdminSeriesFixModalProps {
@@ -33,7 +33,6 @@ export function AdminSeriesEditModal({
 }: AdminSeriesFixModalProps) {
   const { data: categories } = useCategories();
   const { data: seriesDetail } = useSeriesDetail(series?.mediaId ?? null);
-
   const { mutateAsync: fixSeries, isPending } = useFixSeries();
 
   const [title, setTitle] = useState<string>(series?.title ?? "");
@@ -44,13 +43,16 @@ export function AdminSeriesEditModal({
   );
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
+  const [isTagInitialized, setIsTagInitialized] = useState<boolean>(false);
   const [poster, setPoster] = useState<PosterState>({
     posterUrl: null,
     thumbnailUrl: null,
   });
-
+  const [mounted, setMounted] = useState(false);
   const [fixError, setFixError] = useState<boolean>(false);
   const formRef = useRef<HTMLFormElement>(null);
+
+  const { data: tagList } = useTagsByCategory(selectedCategory);
 
   // 시리즈 상세 정보로 폼 초기화
   useEffect(() => {
@@ -64,23 +66,26 @@ export function AdminSeriesEditModal({
     }
   }, [seriesDetail]);
 
-  // 카테고리·태그 초기화
+  // 카테고리 초기화
   useEffect(() => {
     if (categories && series) {
       const categoryId =
         categories.find((c) => c.categoryName === series.categoryName)
           ?.categoryId ?? null;
       setSelectedCategory(categoryId);
-
-      if (categoryId !== null) {
-        const allTags = Object.values(TAGS).flat();
-        const tagIds = series.tagNameList
-          .map((name) => allTags.find((t) => t.name === name)?.tagId)
-          .filter((id): id is number => id !== undefined);
-        setSelectedTags(tagIds);
-      }
     }
   }, [categories, series]);
+
+  // 태그 초기화 (tagList가 로드된 후 API 데이터 기준으로 매핑)
+  useEffect(() => {
+    if (!series || !tagList || isTagInitialized) return;
+    setSelectedTags(
+      series.tagNameList
+        .map((name) => tagList.find((t) => t.name === name)?.tagId)
+        .filter((id): id is number => id !== undefined),
+    );
+    setIsTagInitialized(true);
+  }, [series, tagList, isTagInitialized]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -95,6 +100,10 @@ export function AdminSeriesEditModal({
     return () => {
       document.body.style.overflow = "";
     };
+  }, []);
+
+  useEffect(() => {
+    setMounted(true);
   }, []);
 
   const handleCategoryChange = (category: number | null) => {
@@ -157,12 +166,6 @@ export function AdminSeriesEditModal({
   const handleErrorClose = () => {
     setFixError(false);
   };
-
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
 
   if (!mounted) return null;
 


### PR DESCRIPTION
## 📝 작업 내용

> 시리즈관리 수정 모달에서 생긴 에러를 해결했습니다. 

- [x] poster, thumbnail 이미지 오류 해결
- [x] SelectedTags가 1개만 보이거나, tagId로 보이는 오류 해결

## 📷 구현영상

https://github.com/user-attachments/assets/00f37ab8-96f7-460f-9152-371bae14a694

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`AdminSeriesEditModal.tsx`

- 아래의 코드중 `setPoster`가 없어 그동안 수정 모달창에서 `posterUrl`, `thumbnailUrl`이 있어도 Image가 안나왔습니다. 

```ts
useEffect(() => {
    if (seriesDetail) {
      setDescription(seriesDetail.description);
      setCast(seriesDetail.actors);
      setPoster({
        posterUrl: seriesDetail.posterUrl,
        thumbnailUrl: seriesDetail.thumbnailUrl,
      });
    }
  }, [seriesDetail]);
```

## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #29 

## 💬 리뷰 요구사항

> Vercel 배포는 추후에 다시 시도해보겠습니다! 죄송합니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 시리즈 편집 시 태그 초기화 로직을 개선하여 선택된 카테고리에 따라 태그가 올바르게 로드되도록 수정했습니다.
  * 포스터 데이터가 시리즈 상세 정보에서 제대로 초기화되도록 개선했습니다.

* **개선**
  * 컴포넌트 마운트 상태 관리를 추가하여 초기화 안정성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->