### PR TITLE
[HOTFIX]: image unoptimized=true 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,7 @@ const nextConfig: NextConfig = {
   /* config options here */
   reactCompiler: true,
   images: {
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
## 📝 작업 내용

> **문제**
> 배포 환경에서 이미지가 로드되지 않는 502 에러 발생
>
> **원인**
> CDN(CloudFront)이 Signed Cookie 인증 방식을 사용 중인데, _next/image가 Vercel 서버를 통해 이미지를 프록시할 때 브라우저 쿠키(CloudFront-Key-Pair-Id, CloudFront-Policy, CloudFront-Signature)를 전달하지 못해 인증 실패
>
> **해결**
> unoptimized: true 옵션 추가로 Vercel 프록시를 bypass, 브라우저가 CDN에 직접 요청하여 쿠키 자동 전달

## 📷 스크린샷

## 🖥️ 주요 코드 설명

## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #이슈번호

## 💬 리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 이미지 처리 설정을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->