### PR TITLE
[OT-307] [FEAT]: 모니터링 - 숏폼 -> 콘텐츠 전환율 API 연동

### DIFF
--- a/src/entities/statistics/apis/getShortFormConversion.ts
+++ b/src/entities/statistics/apis/getShortFormConversion.ts
@@ -1,0 +1,14 @@
+import { api } from "@shared/api";
+import { ApiResponse } from "@shared/types";
+
+export interface ShortFormConversion {
+  thisMonthRate: number;
+  rateDiff: number;
+}
+
+export const getShortFormConversion = async () => {
+  const res = await api.get<ApiResponse<ShortFormConversion>>(
+    "/admin/short-form-conversion",
+  );
+  return res.data.data;
+};

--- a/src/entities/statistics/apis/index.ts
+++ b/src/entities/statistics/apis/index.ts
@@ -1,2 +1,3 @@
 export * from "./getTagsByCategory";
 export * from "./getTagStatsByCategory";
+export * from "./getShortFormConversion";

--- a/src/entities/statistics/components/StatisticsContents.tsx
+++ b/src/entities/statistics/components/StatisticsContents.tsx
@@ -6,6 +6,7 @@ import {
   MonitoringCategoryTabs,
 } from "@entities/statistics/components";
 import { useTagStatsByCategory } from "@entities/statistics/hooks";
+import { useShortFormConversion } from "@entities/statistics/hooks";
 import { CategoryStatistic } from "@shared/mocks/mockAdminCategoryStatistics";
 
 export function StatisticsContents() {
@@ -13,6 +14,7 @@ export function StatisticsContents() {
   const [activeCategory, setActiveCategory] = useState<number>(1);
 
   const { data: tagStats } = useTagStatsByCategory(activeCategory);
+  const { data: shortFormConversion } = useShortFormConversion();
 
   const currentStatData: CategoryStatistic = {
     labels: tagStats?.map((t) => t.tagName) ?? [],
@@ -59,17 +61,23 @@ export function StatisticsContents() {
         {/* [오른쪽] 숏폼 콘텐츠 전환율 값 */}
         <div className="flex flex-col col-span-4 rounded-xl p-6 h-90 bg-ot-gray-700">
           <h3 className="text-ot-text font-bold text-[18px]">
-            숏폼 → 콘텐츠 전환율 (월별)
+            숏폼 → 콘텐츠 전환율 (월별) : {currentMonth}월
           </h3>
 
           <div className="flex-1 flex items-center justify-center">
             <div className="w-full flex flex-col items-center justify-center py-10 border border-ot-gray-600 rounded-lg bg-ot-gray-800/50">
               <div className="flex items-center justify-center gap-3">
                 <span className="text-[48px] font-bold text-ot-primary-100">
-                  18.5%
+                  {shortFormConversion?.thisMonthRate.toFixed(1)}%
                 </span>
                 <span className="text-ot-primary-200 text-[18px] font-semibold">
-                  + 2.1% ↑
+                  {shortFormConversion?.rateDiff !== undefined && (
+                    <>
+                      {shortFormConversion.rateDiff >= 0 ? "+" : ""}
+                      {shortFormConversion.rateDiff.toFixed(1)}%
+                      {shortFormConversion.rateDiff >= 0 ? "↑" : "↓"}
+                    </>
+                  )}
                 </span>
               </div>
             </div>

--- a/src/entities/statistics/components/StatisticsContents.tsx
+++ b/src/entities/statistics/components/StatisticsContents.tsx
@@ -69,7 +69,7 @@ export function StatisticsContents() {
           <div className="flex-1 flex items-center justify-center">
             <div className="w-full flex flex-col items-center justify-center py-10 border border-ot-gray-600 rounded-lg bg-ot-gray-800/50">
               {shortFormConversion ? (
-                <div className="flex items-center justify-center gap-3">
+                <div className="flex flex-col lg:flex-row items-center justify-center gap-1 lg:gap-3">
                   <span className="text-[48px] font-bold text-ot-primary-100">
                     {shortFormConversion.thisMonthRate.toFixed(1)}%
                   </span>

--- a/src/entities/statistics/components/StatisticsContents.tsx
+++ b/src/entities/statistics/components/StatisticsContents.tsx
@@ -5,8 +5,10 @@ import {
   CategoryCharts,
   MonitoringCategoryTabs,
 } from "@entities/statistics/components";
-import { useTagStatsByCategory } from "@entities/statistics/hooks";
-import { useShortFormConversion } from "@entities/statistics/hooks";
+import {
+  useShortFormConversion,
+  useTagStatsByCategory,
+} from "@entities/statistics/hooks";
 import { CategoryStatistic } from "@shared/mocks/mockAdminCategoryStatistics";
 
 export function StatisticsContents() {
@@ -66,20 +68,37 @@ export function StatisticsContents() {
 
           <div className="flex-1 flex items-center justify-center">
             <div className="w-full flex flex-col items-center justify-center py-10 border border-ot-gray-600 rounded-lg bg-ot-gray-800/50">
-              <div className="flex items-center justify-center gap-3">
-                <span className="text-[48px] font-bold text-ot-primary-100">
-                  {shortFormConversion?.thisMonthRate.toFixed(1)}%
-                </span>
-                <span className="text-ot-primary-200 text-[18px] font-semibold">
-                  {shortFormConversion?.rateDiff !== undefined && (
-                    <>
-                      {shortFormConversion.rateDiff >= 0 ? "+" : ""}
-                      {shortFormConversion.rateDiff.toFixed(1)}%
-                      {shortFormConversion.rateDiff >= 0 ? "↑" : "↓"}
-                    </>
-                  )}
-                </span>
-              </div>
+              {shortFormConversion ? (
+                <div className="flex items-center justify-center gap-3">
+                  <span className="text-[48px] font-bold text-ot-primary-100">
+                    {shortFormConversion.thisMonthRate.toFixed(1)}%
+                  </span>
+                  <span className="text-ot-primary-200 text-[18px] font-semibold">
+                    {shortFormConversion.rateDiff !== undefined && (
+                      <>
+                        {shortFormConversion.rateDiff >= 0 ? "+" : ""}
+                        {shortFormConversion.rateDiff.toFixed(1)}%
+                        {shortFormConversion.rateDiff >= 0 ? "↑" : "↓"}
+                      </>
+                    )}
+                  </span>
+                </div>
+              ) : (
+                <div className="flex flex-col items-center gap-2">
+                  <div className="flex items-center justify-center gap-3 opacity-30">
+                    <span className="text-ot-placeholder text-[24px]">ex)</span>
+                    <span className="text-[48px] font-bold text-ot-primary-100">
+                      18.5%
+                    </span>
+                    <span className="text-ot-primary-200 text-[18px] font-semibold">
+                      +2.1% ↑
+                    </span>
+                  </div>
+                  <p className="text-ot-placeholder text-sm">
+                    전환율 데이터가 없습니다.
+                  </p>
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/entities/statistics/hooks/index.ts
+++ b/src/entities/statistics/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./useTagsByCategory";
 export * from "./useTagStatsByCategory";
+export * from "./useShortFormConversion";

--- a/src/entities/statistics/hooks/useShortFormConversion.ts
+++ b/src/entities/statistics/hooks/useShortFormConversion.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { getShortFormConversion } from "@entities/statistics/apis";
+
+export const useShortFormConversion = () => {
+  return useQuery({
+    queryKey: ["shortFormConversion"],
+    queryFn: getShortFormConversion,
+  });
+};


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 적어주세요

- [x] 숏폼 -> 콘텐츠 전환율 API 연동

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. src에 이미지 url만 등록하면 됩니다. -->

| 구현 내용 |             SE              |
| :-------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/dabf18e1-eb0f-45eb-b71d-856e48ffe9fe" width ="400"> |
|    GIF    | <img src = "https://github.com/user-attachments/assets/fc71decd-bc80-4261-90d8-ba3e6cf128e2" width ="400"> |
|    GIF    | <img src = "https://github.com/user-attachments/assets/09ad0b53-5979-4809-8ae0-26bc0e90ef09" width ="400"> |

(전환율 데이터 없을 시 예시 임시 데이터 & 안내 문구 표시 추가)

전환율 부분 예시 반응형 추가

https://github.com/user-attachments/assets/723e6f9e-6e06-4f37-ab4e-441b253022e0


## 🖥️ 주요 코드 설명

- src\entities\statistics\apis\getShortFormConversion.ts, src\entities\statistics\hooks\useShortFormConversion.ts : 전환율 API 관련 코드
- src\entities\statistics\components\StatisticsContents.tsx : 모니터링 페이지 중 아래 대시보드 파트 컴포넌트

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`HomeView`

- 전환율 옆에 당월 안내 텍스트 추가 (= 카테고리 태그별 그래프)

```ts
<h3 className="text-ot-text font-bold text-[18px]">
  숏폼 → 콘텐츠 전환율 (월별) : {currentMonth}월
</h3>
```

소수점 아래 한자리 수 까지 출력하도록 표기
```
<span className="text-[48px] font-bold text-ot-primary-100">
  {shortFormConversion?.thisMonthRate.toFixed(1)}%
</span>
<span className="text-ot-primary-200 text-[18px] font-semibold">
  {shortFormConversion?.rateDiff !== undefined && (
    <>
      {shortFormConversion.rateDiff >= 0 ? "+" : ""}
      {shortFormConversion.rateDiff.toFixed(1)}%
      {shortFormConversion.rateDiff >= 0 ? "↑" : "↓"}
    </>
  )}
</span>
```
전환율 데이터 없는 경우 임시 숫자값 & 안내 문구 표시
```
) : (
  <div className="flex flex-col items-center gap-2">
    <div className="flex items-center justify-center gap-3 opacity-30">
      <span className="text-ot-placeholder text-[24px]">ex)</span>
      <span className="text-[48px] font-bold text-ot-primary-100">
        18.5%
      </span>
      <span className="text-ot-primary-200 text-[18px] font-semibold">
        +2.1% ↑
      </span>
    </div>
    <p className="text-ot-placeholder text-sm">
      전환율 데이터가 없습니다.
    </p>
  </div>
)}
```

전환율 표기 부분 예시 반응형 추가 (<div> 부분)
- lg(1024px) 이상이면 가로로 배치, 사이 간격 3, 아니라면 세로로 배치하고 위아래 간격 1
```
{shortFormConversion ? (
  <div className="flex flex-col lg:flex-row items-center justify-center gap-1 lg:gap-3">
    <span className="text-[48px] font-bold text-ot-primary-100">
```


## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #37 

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 통계 패널에 쇼트폼 전환율 데이터 추가
  * 당월 전환율(thisMonthRate)을 소수 첫째 자리로 표시
  * 전월 대비 변화율(rateDiff)을 부호와 화살표로 시각화하여 증감 표시
  * 우측 패널에 현재 월 표기를 추가하고 기존 정적 메트릭을 실시간 데이터로 대체
<!-- end of auto-generated comment: release notes by coderabbit.ai -->