### PR TITLE
[OT-318] [FEAT]: 콘텐츠, 숏폼 멀티파트 업로드 API 연동

### DIFF
--- a/src/entities/shorts/apis/shortsApi.ts
+++ b/src/entities/shorts/apis/shortsApi.ts
@@ -1,4 +1,5 @@
 import { api } from "@shared/api";
+import { UploadedPart } from "@shared/lib";
 import { ApiResponse, PublicStatus } from "@shared/types";
 
 export interface UploadShortsRequest {
@@ -22,7 +23,9 @@ export interface UploadShortsResponse {
   masterPlaylistObjectKey: string;
   posterUploadUrl: string; // S3에 업로드할 때 사용할 URL - 포스터 이미지 파일
   thumbnailUploadUrl: string; // S3에 업로드할 때 사용할 URL - 썸네일 이미지 파일
-  originUploadUrl: string; // S3에 업로드할 때 사용할 URL - 원본 영상 파일
+  originUploadId: string;
+  originTotalPartCount: number;
+  originPartSizeBytes: number;
 }
 
 // 콘텐츠 업로드 API
@@ -32,6 +35,24 @@ export const uploadShortsApi = async (body: UploadShortsRequest) => {
     body,
   );
   return res.data.data;
+};
+
+// 멀티파트 완료 post
+export interface CompleteMultipartRequest {
+  objectKey: string;
+  uploadId: string;
+  parts: UploadedPart[];
+}
+
+export const completeMultipartUploadApi = async (
+  shortformId: number,
+  body: CompleteMultipartRequest,
+) => {
+  const res = await api.post<ApiResponse<void>>(
+    `/short-forms/${shortformId}/upload/complete`,
+    body,
+  );
+  return res.data;
 };
 
 export interface UpdateShortsRequest {

--- a/src/entities/shorts/hooks/useUpdateShorts.ts
+++ b/src/entities/shorts/hooks/useUpdateShorts.ts
@@ -1,9 +1,8 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { UpdateShortsRequest, updateShortsApi } from "@entities/shorts/apis";
 
 // 숏폼 수정
 export const useUpdateShorts = () => {
-  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({
       shortformId,
@@ -12,8 +11,5 @@ export const useUpdateShorts = () => {
       shortformId: number;
       body: UpdateShortsRequest;
     }) => updateShortsApi(shortformId, body),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["shorts", "list"] });
-    },
   });
 };

--- a/src/entities/shorts/hooks/useUploadShorts.ts
+++ b/src/entities/shorts/hooks/useUploadShorts.ts
@@ -1,13 +1,9 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { UploadShortsRequest, uploadShortsApi } from "@entities/shorts/apis";
 
 // 숏폼 업로드
 export const useUploadShorts = () => {
-  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (body: UploadShortsRequest) => uploadShortsApi(body),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["shorts", "list"] });
-    },
   });
 };

--- a/src/entities/video-contents/apis/videoContentsApi.ts
+++ b/src/entities/video-contents/apis/videoContentsApi.ts
@@ -1,4 +1,5 @@
 import { api } from "@shared/api";
+import { UploadedPart } from "@shared/lib";
 import { ApiResponse, PublicStatus } from "@shared/types";
 
 export interface UploadVideoRequest {
@@ -22,9 +23,11 @@ export interface UploadVideoResponse {
   thumbnailObjectKey: string;
   originObjectKey: string;
   masterPlaylistObjectKey: string;
-  posterUploadUrl: string; // S3에 업로드할 때 사용할 URL - 포스터 이미지 파일
-  thumbnailUploadUrl: string; // S3에 업로드할 때 사용할 URL - 썸네일 이미지 파일
-  originUploadUrl: string; // S3에 업로드할 때 사용할 URL - 원본 영상 파일 (n개 예정)
+  posterUploadUrl: string;
+  thumbnailUploadUrl: string;
+  originUploadId: string;
+  originTotalPartCount: number;
+  originPartSizeBytes: number;
 }
 
 // 콘텐츠 업로드 API
@@ -34,6 +37,24 @@ export const uploadVideoApi = async (body: UploadVideoRequest) => {
     body,
   );
   return res.data.data;
+};
+
+// 멀티파트 완료 post
+export interface CompleteMultipartRequest {
+  objectKey: string;
+  uploadId: string;
+  parts: UploadedPart[];
+}
+
+export const completeMultipartUploadApi = async (
+  contentsId: number,
+  body: CompleteMultipartRequest,
+) => {
+  const res = await api.post<ApiResponse<void>>(
+    `/admin/contents/${contentsId}/upload/complete`,
+    body,
+  );
+  return res.data;
 };
 
 export interface UpadteVideoRequest {
@@ -52,11 +73,8 @@ export interface UpadteVideoResponse {
   contentsId: number;
   posterObjectKey: string;
   thumbnailObjectKey: string;
-  originObjectKey: string;
-  masterPlaylistObjectKey: string;
   posterUploadUrl: string; // S3에 업로드할 때 사용할 URL - 포스터 이미지 파일
   thumbnailUploadUrl: string; // S3에 업로드할 때 사용할 URL - 썸네일 이미지 파일
-  originUploadUrl: string; // S3에 업로드할 때 사용할 URL - 원본 영상 파일 (n개 예정)
 }
 
 // 콘텐츠 수정 API

--- a/src/entities/video-contents/hooks/useUploadVideoContents.ts
+++ b/src/entities/video-contents/hooks/useUploadVideoContents.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import {
   UploadVideoRequest,
   updateVideoApi,
@@ -6,18 +6,12 @@ import {
 } from "@entities/video-contents/apis";
 
 export const useUploadVideoContents = () => {
-  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (body: UploadVideoRequest) => uploadVideoApi(body),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["contents", "list"] });
-    },
   });
 };
 
 export const useUpdateVideoContents = () => {
-  const queryClient = useQueryClient();
-
   return useMutation({
     mutationFn: ({
       contentsId,
@@ -26,8 +20,5 @@ export const useUpdateVideoContents = () => {
       contentsId: number;
       body: UploadVideoRequest;
     }) => updateVideoApi(contentsId, body),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["contents", "list"] });
-    },
   });
 };

--- a/src/features/shorts-manage/AdminShortsEditModal.tsx
+++ b/src/features/shorts-manage/AdminShortsEditModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { uploadFileToS3 } from "@/shared/lib";
+import { useQueryClient } from "@tanstack/react-query";
 import { X } from "lucide-react";
 import { OriginMediaItem } from "@entities/originMedia/apis";
 import { AdminOriginalContentsDropdown } from "@entities/originMedia/components";
@@ -27,6 +28,7 @@ export function AdminShortsEditModal({
   mediaId,
   onClose,
 }: AdminShortsEditModalProps) {
+  const queryClient = useQueryClient();
   const { data, isLoading, isError } = useShortsDetail(mediaId);
   const { mutateAsync: updateShorts, isPending } = useUpdateShorts();
 
@@ -106,6 +108,7 @@ export function AdminShortsEditModal({
         if (poster.posterFile) {
           await uploadFileToS3(posterUploadUrl, poster.posterFile);
         }
+        queryClient.invalidateQueries({ queryKey: ["shorts", "list"] });
         onClose();
       } catch (error) {
         setUploadError(true);

--- a/src/features/shorts-manage/AdminShortsUploadModal.tsx
+++ b/src/features/shorts-manage/AdminShortsUploadModal.tsx
@@ -20,6 +20,7 @@ import {
   ConfirmModal,
   PosterState,
 } from "@shared/components";
+import { MAX_FILE_SIZE, MIN_FILE_SIZE } from "@shared/constants";
 import { useIsMounted } from "@shared/hooks";
 import {
   UploadedPart,
@@ -91,10 +92,13 @@ export function AdminShortsUploadModal({
     e.preventDefault();
     if (!videoFile || !selectedOriginal) return;
 
-    // 5MB 미만 파일 업로드 차단
-    const MIN_FILE_SIZE = 5 * 1024 * 1024;
+    // 5MB 미만, 200GB 초과 파일 업로드 차단
     if (videoFile.size < MIN_FILE_SIZE) {
       alert("영상 파일은 5MB 이상이어야 합니다.");
+      return;
+    }
+    if (videoFile!.size > MAX_FILE_SIZE) {
+      alert("영상 파일은 200GB 이하여야 합니다.");
       return;
     }
 

--- a/src/features/shorts-manage/AdminShortsUploadModal.tsx
+++ b/src/features/shorts-manage/AdminShortsUploadModal.tsx
@@ -2,12 +2,14 @@
 
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { useIsMounted } from "@/shared/hooks";
-import { uploadFileToS3 } from "@/shared/lib";
+import { useQueryClient } from "@tanstack/react-query";
 import { X } from "lucide-react";
 import { OriginMediaItem } from "@entities/originMedia/apis";
 import { AdminOriginalContentsDropdown } from "@entities/originMedia/components";
-import { UploadShortsRequest } from "@entities/shorts/apis";
+import {
+  UploadShortsRequest,
+  completeMultipartUploadApi,
+} from "@entities/shorts/apis";
 import { useUploadShorts } from "@entities/shorts/hooks";
 import {
   AdminFileUpload,
@@ -18,6 +20,13 @@ import {
   ConfirmModal,
   PosterState,
 } from "@shared/components";
+import { useIsMounted } from "@shared/hooks";
+import {
+  UploadedPart,
+  getShortFormPartUploadUrls,
+  uploadFileToS3,
+  uploadVideoMultipart,
+} from "@shared/lib";
 import { VideoFileMeta } from "@shared/types";
 
 interface AdminShortsUploadModalProps {
@@ -30,6 +39,7 @@ export function AdminShortsUploadModal({
   onClose,
 }: AdminShortsUploadModalProps) {
   const mounted = useIsMounted();
+  const queryClient = useQueryClient();
   const { mutateAsync: uploadShorts, isPending } = useUploadShorts();
 
   const [title, setTitle] = useState<string>("");
@@ -42,6 +52,7 @@ export function AdminShortsUploadModal({
     posterUrl: null,
   });
   const [uploadError, setUploadError] = useState<boolean>(false);
+  const [isUploading, setIsUploading] = useState<boolean>(false);
 
   const formRef = useRef<HTMLFormElement>(null);
   const isFormValid =
@@ -69,9 +80,25 @@ export function AdminShortsUploadModal({
 
   if (!mounted || !open) return null;
 
+  const isLoading = isPending || isUploading;
+
+  const handleClose = () => {
+    if (isLoading) return;
+    onClose();
+  };
+
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!videoFile || !selectedOriginal) return;
+
+    // 5MB 미만 파일 업로드 차단
+    const MIN_FILE_SIZE = 5 * 1024 * 1024;
+    if (videoFile.size < MIN_FILE_SIZE) {
+      alert("영상 파일은 5MB 이상이어야 합니다.");
+      return;
+    }
+
+    setIsUploading(true);
 
     const body: UploadShortsRequest = {
       title,
@@ -80,34 +107,58 @@ export function AdminShortsUploadModal({
       publicStatus: isPublic ? "PUBLIC" : "PRIVATE",
       originId: selectedOriginal.originId,
       duration: videoFile.duration,
-      videoSize: videoFile.size,
+      videoSize: Math.ceil(videoFile.size / 1024), // bytes → KB 변환 과정
       posterFileName: poster.posterFile?.name,
       thumbnailFileName: poster.thumbnailFile?.name,
-      originFileName: videoFile!.name,
+      originFileName: videoFile.name,
     };
+
     try {
       // throw new Error("강제 에러 테스트"); // error 테스트 시 주석 해제
-      const { posterUploadUrl, originUploadUrl } = await uploadShorts(body);
 
-      // S3 직접 업로드 (병렬)
-      await Promise.all([
+      // 1. 메타데이터 전송 → Presigned URL 수신
+      const {
+        shortFormId,
+        posterUploadUrl,
+        originUploadId,
+        originObjectKey,
+        originTotalPartCount,
+        originPartSizeBytes,
+      } = await uploadShorts(body);
+
+      // 2. S3 직접 업로드 (병렬)
+      const [, parts] = await Promise.all([
         poster.posterFile
           ? uploadFileToS3(posterUploadUrl, poster.posterFile)
           : Promise.resolve(),
         videoFile.file
-          ? uploadFileToS3(originUploadUrl, videoFile.file)
-          : Promise.resolve(),
+          ? uploadVideoMultipart(
+              shortFormId,
+              originUploadId,
+              originObjectKey,
+              videoFile.file,
+              originPartSizeBytes,
+              originTotalPartCount,
+              getShortFormPartUploadUrls,
+            )
+          : Promise.resolve([]),
       ]);
+
+      // 3. 멀티파트 완료 요청
+      await completeMultipartUploadApi(shortFormId, {
+        objectKey: originObjectKey,
+        uploadId: originUploadId,
+        parts: parts as UploadedPart[],
+      });
+
+      queryClient.invalidateQueries({ queryKey: ["shorts", "list"] }); // 영상 업로드 completed 성공 시 list invalidate
       onClose();
     } catch (error) {
       console.error("업로드 실패:", error);
-      setUploadError(true);
+      setUploadError(true); //실패 시 재시도 모달만 뜸, onClose() 안 탐
+    } finally {
+      setIsUploading(false);
     }
-  };
-
-  const handleClose = () => {
-    if (isPending) return;
-    onClose();
   };
 
   const handleRetry = () => {
@@ -189,16 +240,16 @@ export function AdminShortsUploadModal({
                   onClick={handleClose}
                   className="py-3 font-semibold"
                   variant="outline"
-                  disabled={isPending}
+                  disabled={isLoading}
                 >
                   취소
                 </CommonButton>
                 <CommonButton
                   type="submit"
                   className="py-3 font-semibold"
-                  disabled={isPending || !isFormValid}
+                  disabled={isLoading || !isFormValid}
                 >
-                  {isPending ? "업로드 중..." : "업로드 시작"}
+                  {isLoading ? "업로드 중..." : "업로드 시작"}
                 </CommonButton>
               </div>
             </form>
@@ -213,7 +264,7 @@ export function AdminShortsUploadModal({
         cancelText="취소"
         onConfirm={handleRetry}
         onClose={() => setUploadError(false)}
-        disabled={isPending}
+        disabled={isLoading}
       />
     </>
   );

--- a/src/features/video-contents-manage/components/AdminVideoContentsEditModal.tsx
+++ b/src/features/video-contents-manage/components/AdminVideoContentsEditModal.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTagsByCategory } from "@/entities/statistics/hooks";
+import { useQueryClient } from "@tanstack/react-query";
 import { X } from "lucide-react";
 import { AdminContentTypeSelector } from "@features/video-contents-manage/components";
 import { AdminCategoryDropdown } from "@entities/category/components";
@@ -34,6 +35,7 @@ export function AdminVideoContentsEditModal({
   mediaId,
   onClose,
 }: AdminVideoContentsEditModalProps) {
+  const queryClient = useQueryClient();
   const { data, isLoading, isError } = useContentDetail(mediaId);
   const { data: categories } = useCategories();
   const { mutateAsync: updateVideo, isPending } = useUpdateVideoContents();
@@ -200,10 +202,10 @@ export function AdminVideoContentsEditModal({
 
       const failed = s3Results.filter((r) => r.status === "rejected");
       if (failed.length > 0) {
-        console.error("실패한 업로드:", failed);
         setUploadError(true);
         return;
       }
+      queryClient.invalidateQueries({ queryKey: ["contents", "list"] });
       onClose();
     } catch (error) {
       console.error("수정 실패:", error);

--- a/src/features/video-contents-manage/components/AdminVideoContentsUploadModal.tsx
+++ b/src/features/video-contents-manage/components/AdminVideoContentsUploadModal.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { MAX_FILE_SIZE, MIN_FILE_SIZE } from "@/shared/constants";
 import { useQueryClient } from "@tanstack/react-query";
 import { X } from "lucide-react";
 import { AdminContentTypeSelector } from "@features/video-contents-manage/components";
@@ -157,9 +158,12 @@ function ModalInner({ onClose }: { onClose: () => void }) {
     e.preventDefault();
 
     // 5MB 미만 파일 업로드 차단
-    const MIN_FILE_SIZE = 5 * 1024 * 1024; // 5MB
     if (videoFile!.size < MIN_FILE_SIZE) {
       alert("영상 파일은 5MB 이상이어야 합니다.");
+      return;
+    }
+    if (videoFile!.size > MAX_FILE_SIZE) {
+      alert("영상 파일은 200GB 이하여야 합니다.");
       return;
     }
 

--- a/src/features/video-contents-manage/components/AdminVideoContentsUploadModal.tsx
+++ b/src/features/video-contents-manage/components/AdminVideoContentsUploadModal.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import { X } from "lucide-react";
 import { AdminContentTypeSelector } from "@features/video-contents-manage/components";
 import { AdminCategoryDropdown } from "@entities/category/components";
@@ -12,6 +13,7 @@ import { AdminTagDropdown } from "@entities/tag/components";
 import {
   SeriesTitleItem,
   UploadVideoRequest,
+  completeMultipartUploadApi,
 } from "@entities/video-contents/apis";
 import { useUploadVideoContents } from "@entities/video-contents/hooks";
 import {
@@ -24,7 +26,12 @@ import {
   PosterState,
 } from "@shared/components";
 import { useIsMounted } from "@shared/hooks";
-import { uploadFileToS3 } from "@shared/lib";
+import {
+  UploadedPart,
+  getContentsPartUploadUrls,
+  uploadFileToS3,
+  uploadVideoMultipart,
+} from "@shared/lib";
 import { ContentType, VideoFileMeta } from "@shared/types";
 
 interface AdminUploadModalProps {
@@ -51,6 +58,7 @@ export function AdminVideoContentsUploadModal({
 }
 
 function ModalInner({ onClose }: { onClose: () => void }) {
+  const queryClient = useQueryClient();
   const { mutateAsync: uploadVideo, isPending } = useUploadVideoContents();
   const { data: categories } = useCategories();
 
@@ -73,6 +81,8 @@ function ModalInner({ onClose }: { onClose: () => void }) {
   const { data: tagList } = useTagsByCategory(selectedCategory);
   const formRef = useRef<HTMLFormElement>(null);
 
+  const [isUploading, setIsUploading] = useState<boolean>(false);
+  const isLoading = isPending || isUploading;
   // pendingTagNames 있으면 tagList 로드 후 세팅
   useEffect(() => {
     if (!pendingTagNames || !tagList) return;
@@ -139,12 +149,21 @@ function ModalInner({ onClose }: { onClose: () => void }) {
   };
 
   const handleClose = () => {
-    if (isPending) return;
+    if (isLoading) return;
     onClose();
   };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    // 5MB 미만 파일 업로드 차단
+    const MIN_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+    if (videoFile!.size < MIN_FILE_SIZE) {
+      alert("영상 파일은 5MB 이상이어야 합니다.");
+      return;
+    }
+
+    setIsUploading(true);
 
     const body: UploadVideoRequest = {
       title,
@@ -154,7 +173,7 @@ function ModalInner({ onClose }: { onClose: () => void }) {
       categoryId: selectedCategory!,
       tagIdList: selectedTags,
       duration: videoFile!.duration,
-      videoSize: videoFile!.size,
+      videoSize: Math.ceil(videoFile!.size / 1024),
       seriesId:
         contentType === "시리즈" ? (selectedSeries ?? undefined) : undefined,
       posterFileName: poster.posterFile?.name,
@@ -166,11 +185,18 @@ function ModalInner({ onClose }: { onClose: () => void }) {
       // throw new Error("강제 에러 테스트"); // error 테스트 시 주석 해제
 
       // 1. 메타데이터 전송 → Presigned URL 수신
-      const { posterUploadUrl, thumbnailUploadUrl, originUploadUrl } =
-        await uploadVideo(body);
+      const {
+        contentsId,
+        posterUploadUrl,
+        thumbnailUploadUrl,
+        originUploadId,
+        originObjectKey,
+        originTotalPartCount,
+        originPartSizeBytes,
+      } = await uploadVideo(body);
 
       // 2. S3 직접 업로드 (병렬)
-      await Promise.all([
+      const [, , parts] = await Promise.all([
         poster.posterFile
           ? uploadFileToS3(posterUploadUrl, poster.posterFile)
           : Promise.resolve(),
@@ -178,14 +204,31 @@ function ModalInner({ onClose }: { onClose: () => void }) {
           ? uploadFileToS3(thumbnailUploadUrl, poster.thumbnailFile)
           : Promise.resolve(),
         videoFile!.file
-          ? uploadFileToS3(originUploadUrl, videoFile!.file)
-          : Promise.resolve(),
+          ? uploadVideoMultipart(
+              contentsId,
+              originUploadId,
+              originObjectKey,
+              videoFile!.file,
+              originPartSizeBytes,
+              originTotalPartCount,
+              getContentsPartUploadUrls,
+            )
+          : Promise.resolve([]),
       ]);
 
+      // 3. 멀티파트 완료 요청
+      await completeMultipartUploadApi(contentsId, {
+        objectKey: originObjectKey,
+        uploadId: originUploadId,
+        parts: parts as UploadedPart[],
+      });
+      queryClient.invalidateQueries({ queryKey: ["contents", "list"] });
       onClose();
     } catch (error) {
       console.error("업로드 실패:", error);
-      setUploadError(true);
+      setUploadError(true); // 실패 시 재시도 모달만 뜸, onClose() 안 탐
+    } finally {
+      setIsUploading(false); // 성공/실패 모두 로딩 해제
     }
   };
 
@@ -283,16 +326,16 @@ function ModalInner({ onClose }: { onClose: () => void }) {
                   onClick={handleClose}
                   className="py-3 font-semibold"
                   variant="outline"
-                  disabled={isPending}
+                  disabled={isLoading}
                 >
                   취소
                 </CommonButton>
                 <CommonButton
                   type="submit"
                   className="py-3 font-semibold"
-                  disabled={isPending || !isFormValid}
+                  disabled={isLoading || !isFormValid}
                 >
-                  {isPending ? "업로드 중..." : "업로드 시작"}
+                  {isLoading ? "업로드 중..." : "업로드 시작"}
                 </CommonButton>
               </div>
             </form>

--- a/src/shared/components/AdminFileUpload.tsx
+++ b/src/shared/components/AdminFileUpload.tsx
@@ -13,9 +13,25 @@ export interface AdminFileUploadProps {
 export function AdminFileUpload({ value, onChange }: AdminFileUploadProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const MIN_FILE_SIZE = 5 * 1024 * 1024; // 5MB (최소)
+  const MAX_FILE_SIZE = 200 * 1024 * 1024 * 1024; // 200GB (최대)
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+
+    // 파일 크기 검증
+    if (file.size < MIN_FILE_SIZE) {
+      alert("영상 파일은 5MB 이상이어야 합니다.");
+      e.target.value = "";
+      return;
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      alert("영상 파일은 200GB 이하이어야 합니다.");
+      e.target.value = "";
+      return;
+    }
+
     const video = document.createElement("video");
     video.preload = "metadata";
     video.src = URL.createObjectURL(file);
@@ -77,7 +93,7 @@ export function AdminFileUpload({ value, onChange }: AdminFileUploadProps) {
             클릭하여 파일 선택 또는 드래그 앤 드롭
           </span>
           <span className="text-xs text-ot-gray-700 mt-1">
-            MP4, MOV, AVI (최대 10GB)
+            MP4, MOV, WEBM (5MB 이상 · 최대 200GB)
           </span>
         </label>
       )}

--- a/src/shared/components/AdminFileUpload.tsx
+++ b/src/shared/components/AdminFileUpload.tsx
@@ -2,6 +2,7 @@
 
 import { useRef } from "react";
 import { Film, Upload, X } from "lucide-react";
+import { MAX_FILE_SIZE, MIN_FILE_SIZE } from "@shared/constants";
 import { formatDuration, formatSize } from "@shared/lib";
 import { VideoFileMeta } from "@shared/types";
 
@@ -12,9 +13,6 @@ export interface AdminFileUploadProps {
 
 export function AdminFileUpload({ value, onChange }: AdminFileUploadProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-
-  const MIN_FILE_SIZE = 5 * 1024 * 1024; // 5MB (최소)
-  const MAX_FILE_SIZE = 200 * 1024 * 1024 * 1024; // 200GB (최대)
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -27,7 +25,7 @@ export function AdminFileUpload({ value, onChange }: AdminFileUploadProps) {
       return;
     }
     if (file.size > MAX_FILE_SIZE) {
-      alert("영상 파일은 200GB 이하이어야 합니다.");
+      alert("영상 파일은 200GB 이하여야 합니다.");
       e.target.value = "";
       return;
     }

--- a/src/shared/constants/fileSize.ts
+++ b/src/shared/constants/fileSize.ts
@@ -1,0 +1,2 @@
+export const MIN_FILE_SIZE = 5 * 1024 * 1024; // 5MB (최소)
+export const MAX_FILE_SIZE = 200 * 1024 * 1024 * 1024; // 200GB (최대)

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,0 +1,1 @@
+export { MAX_FILE_SIZE, MIN_FILE_SIZE } from "./fileSize";

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,3 +1,3 @@
 export { formatSize, formatDuration } from "./format";
 export { toPublicStatus } from "./publicConvert";
-export { uploadFileToS3 } from "./uploadFileS3";
+export * from "./uploadFileS3";

--- a/src/shared/lib/uploadFileS3.ts
+++ b/src/shared/lib/uploadFileS3.ts
@@ -1,3 +1,7 @@
+import { api } from "@shared/api";
+import { ApiResponse, PageInfo } from "@shared/types";
+
+// S3 단일 파일 업로드 (포스터, 썸네일용)
 export const uploadFileToS3 = async (uploadUrl: string, file: File) => {
   await fetch(uploadUrl, {
     method: "PUT",
@@ -6,4 +10,120 @@ export const uploadFileToS3 = async (uploadUrl: string, file: File) => {
       "Content-Type": file.type,
     },
   });
+};
+
+export interface UploadedPart {
+  partNumber: number;
+  eTag: string;
+}
+
+interface PartUploadItem {
+  partNumber: number;
+  uploadUrl: string;
+}
+
+interface PartPageResponse {
+  pageInfo: PageInfo;
+  dataList: PartUploadItem[];
+}
+
+// 멀티파트 업로드용 Presigned URL 페이지 단위 조회 (콘텐츠)
+export const getContentsPartUploadUrls = async (
+  contentsId: number,
+  objectKey: string,
+  uploadId: string,
+  page: number,
+  size: number,
+): Promise<PartPageResponse> => {
+  const res = await api.get<ApiResponse<PartPageResponse>>(
+    `/admin/contents/${contentsId}/upload/parts`,
+    {
+      params: { objectKey, uploadId, page, size },
+    },
+  );
+  return res.data.data;
+};
+
+// 멀티파트 업로드용 Presigned URL 페이지 단위 조회 (숏폼)
+export const getShortFormPartUploadUrls = async (
+  contentsId: number,
+  objectKey: string,
+  uploadId: string,
+  page: number,
+  size: number,
+): Promise<PartPageResponse> => {
+  const res = await api.get<ApiResponse<PartPageResponse>>(
+    `/short-forms/${contentsId}/upload/parts`,
+    {
+      params: { objectKey, uploadId, page, size },
+    },
+  );
+  return res.data.data;
+};
+
+type GetPartUploadUrlsFn = (
+  contentsId: number,
+  objectKey: string,
+  uploadId: string,
+  page: number,
+  size: number,
+) => Promise<PartPageResponse>;
+
+// 원본 영상 멀티파트 업로드
+// - 페이지 단위로 Presigned URL 조회 후 파트별 청크 분할 PUT
+// - 각 파트의 ETag를 수집해 반환 (complete API에서 사용)
+export const uploadVideoMultipart = async (
+  contentsId: number,
+  uploadId: string,
+  objectKey: string,
+  file: File,
+  partSizeBytes: number,
+  totalPartCount: number,
+  getPartUrls: GetPartUploadUrlsFn, // 콘텐츠/숏폼 URL 조회 함수 주입
+  onProgress?: (uploadedParts: number, totalParts: number) => void,
+  pageSize = 100,
+): Promise<UploadedPart[]> => {
+  const parts: UploadedPart[] = [];
+
+  let page = 0;
+  let totalPage = 1; // 첫 응답 전 임시값, 이후 실제 totalPage로 갱신
+
+  while (page < totalPage) {
+    const { pageInfo, dataList } = await getPartUrls(
+      contentsId,
+      objectKey,
+      uploadId,
+      page,
+      pageSize,
+    );
+
+    totalPage = pageInfo.totalPage;
+
+    for (let i = 0; i < dataList.length; i++) {
+      const { partNumber, uploadUrl } = dataList[i];
+
+      // 파트 크기 단위로 청크 분할 (마지막 파트는 남은 크기만큼)
+      const start = (partNumber - 1) * partSizeBytes;
+      const end = Math.min(start + partSizeBytes, file.size);
+      const chunk = file.slice(start, end);
+
+      // S3 직접 PUT (Presigned URL 사용, 인증 헤더 불필요)
+      const res = await fetch(uploadUrl, {
+        method: "PUT",
+        body: chunk,
+      });
+
+      if (!res.ok) throw new Error(`Part ${partNumber} upload failed`);
+
+      const eTag = res.headers.get("ETag");
+      if (!eTag) throw new Error(`Part ${partNumber}: ETag header missing`);
+
+      parts.push({ partNumber, eTag });
+      onProgress?.(parts.length, totalPartCount);
+    }
+
+    page++;
+  }
+
+  return parts;
 };


### PR DESCRIPTION
## 📝 작업 내용

> 구현
> - 기존 단일 Url 업로드 -> 멀티파트 업로드 전환
>    -  영상 파일 크기: 5MB - 200GB 로 제한 (이외 영상 업로드 시 alert)
>
> 버그수정
> - 업로드/수정 시 list의 썸네일이 즉시 갱신이 안되는 문제 해결
>    - 업로드 complete 완료 후 목록 갱신하도록 수정 - 기존 hooks의 onSuccess invaildate 제거 후 complete 이후 시점으로 이동


## 📷 스크린샷

- 콘텐츠 업로드 (아래 영상은 썸네일 즉시 갱신 전 영상입니다. 현재는 즉시 갱신되는 것 확인했습니다.)

https://github.com/user-attachments/assets/10d8c3f0-9584-4c7b-850b-9aa112d78ba7

- 숏폼 업로드 (아래 영상은 썸네일 즉시 갱신 전 영상입니다. 현재는 즉시 갱신되는 것 확인했습니다.)

https://github.com/user-attachments/assets/7ede652f-c92e-4d03-b1ff-8c3c8edbac63

- 멀티파트 로직 도식화

<img width="562" height="696" alt="image" src="https://github.com/user-attachments/assets/f8672977-7a96-48d3-b901-97b34feaa65f" />


## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`uploadFileS3 - uploadVideoMultipart`

- Presigned URL을 한 번에 다 받지 않고 페이지 단위(100개씩)로 조회하면서 순차적으로 청크를 PUT합니다. 
- 콘텐츠와 숏폼의 URL 조회 엔드포인트가 다르기 때문에 getPartUrls를 외부에서 주입받는 방식으로 재사용성을 확보했습니다.

```ts
export const uploadVideoMultipart = async (
  contentsId: number,
  uploadId: string,
  objectKey: string,
  file: File,
  partSizeBytes: number,
  totalPartCount: number,
  getPartUrls: GetPartUploadUrlsFn, // 콘텐츠/숏폼 분기를 함수 주입으로 처리
  onProgress?: (uploadedParts: number, totalParts: number) => void,
  pageSize = 100,
): Promise<UploadedPart[]>
```

`uploadFileS3`

- 파트 크기는 서버가 내려준 `originPartSizeBytes` 기준으로 분할합니다. 마지막 파트는 `Math.min`으로 파일 끝을 넘지 않게 처리해 5MB 미만이어도 정상 업로드됩니다.

```ts
const start = (partNumber - 1) * partSizeBytes;
const end = Math.min(start + partSizeBytes, file.size);
const chunk = file.slice(start, end); // 마지막 파트는 남은 크기만큼 자동으로 잘림
```

`HomeView`

- S3는 각 파트 PUT 응답 헤더에 `ETag`를 반환합니다. 이를 parts[]에 누적했다가 모든 파트 업로드 완료 후 `POST /upload/complete`에 전달하면 S3가 순서와 무결성을 검증해 파일을 병합합니다. 
- ETag 없이는 complete 자체가 불가능하기 때문에 누락 시 즉시 throw 처리했습니다.

```ts
const eTag = res.headers.get("ETag");
parts.push({ partNumber, eTag });
```

`콘텐츠,숏폼 업로드/수정 modal`

- onSuccess는 POST /upload (메타데이터 저장) 완료 시점에 실행되기 때문에 이 시점엔 S3에 이미지가 없습니다. 
- complete 이후로 이동해 포스터 이미지가 항상 정상적으로 노출되도록 수정했습니다.

```ts
// Before: mutation onSuccess에서 즉시 invalidate → S3 업로드 전이라 이미지 깨짐
onSuccess: () => {
  queryClient.invalidateQueries({ queryKey: ["shorts", "list"] });
}

// After: complete API 완료 후 invalidate → 모든 파일이 S3에 올라간 시점 보장
await completeMultipartUploadApi(shortFormId, { ... });
queryClient.invalidateQueries({ queryKey: ["shorts", "list"] });
```


## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #39 

## 💬 리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 영상 및 숏폼에 멀티파트 업로드 워크플로우 도입(분할 업로드 및 완료 처리)
  * 업로드 진행 상태 및 UI 로딩 처리 개선(취소 제한·중복 업로드 방지)

* **개선**
  * 파일 크기 검증 추가: 최소 5MB · 최대 200GB, 안내 문구 갱신(MP4, MOV, WEBM)

* **버그 수정**
  * 업로드 완료 후 목록 갱신 흐름 조정(일부 컴포넌트에서 성공 시 목록을 명시적으로 갱신)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->