### PR TITLE
[OT-324] [FEAT, FIX]: EDITOR 권한에 따른 도메인 접근 제어, proxy token 조건 수정

### DIFF
--- a/src/app/(with-layouts)/monitoring/page.tsx
+++ b/src/app/(with-layouts)/monitoring/page.tsx
@@ -1,12 +1,11 @@
-// /monitoring
 import { MonitoringContents } from "@entities/monitoring/components";
-import { StatisticsContents } from "@entities/statistics/components";
+import { StatisticsRoleGuardWrapper } from "@entities/statistics/components";
 
 export default function MonitoringPage() {
   return (
     <main className="flex flex-col">
       <MonitoringContents />
-      <StatisticsContents />
+      <StatisticsRoleGuardWrapper />
     </main>
   );
 }

--- a/src/app/(with-layouts)/series/layout.tsx
+++ b/src/app/(with-layouts)/series/layout.tsx
@@ -1,5 +1,7 @@
 import { AdminTitle } from "@layouts";
 import { AdminSeriesUploadButton } from "@features/series-manage/components";
+import { RoleGuard } from "@shared/components";
+import { ROLES } from "@shared/constants";
 
 export default function SeriesLayout({
   children,
@@ -7,14 +9,13 @@ export default function SeriesLayout({
   children: React.ReactNode;
 }) {
   return (
-    <>
+    <RoleGuard allowedRole={[ROLES.ADMIN]}>
       <AdminTitle
         title="시리즈 관리"
         description="콘텐츠 시리즈를 관리합니다."
         action={<AdminSeriesUploadButton />}
       />
-
       <div className="px-12 pb-12">{children}</div>
-    </>
+    </RoleGuard>
   );
 }

--- a/src/app/(with-layouts)/user/layout.tsx
+++ b/src/app/(with-layouts)/user/layout.tsx
@@ -1,4 +1,6 @@
 import { AdminTitle } from "@layouts";
+import { RoleGuard } from "@shared/components";
+import { ROLES } from "@shared/constants";
 
 export default function UserLayout({
   children,
@@ -6,13 +8,12 @@ export default function UserLayout({
   children: React.ReactNode;
 }) {
   return (
-    <>
+    <RoleGuard allowedRole={[ROLES.ADMIN]}>
       <AdminTitle
         title="전체 유저 관리"
         description="일반 사용자 및 에디터를 관리합니다. (역할 변경은 에디터 ↔ 중지됨만 가능합니다)"
       />
-
       <div className="px-12 pb-12">{children}</div>
-    </>
+    </RoleGuard>
   );
 }

--- a/src/app/(with-layouts)/video-contents/layout.tsx
+++ b/src/app/(with-layouts)/video-contents/layout.tsx
@@ -1,5 +1,7 @@
 import { AdminTitle } from "@layouts";
 import { AdminVideoContentsUploadButton } from "@features/video-contents-manage/components";
+import { RoleGuard } from "@shared/components";
+import { ROLES } from "@shared/constants";
 
 export default function VideoContentsLayout({
   children,
@@ -7,14 +9,13 @@ export default function VideoContentsLayout({
   children: React.ReactNode;
 }) {
   return (
-    <>
+    <RoleGuard allowedRole={[ROLES.ADMIN]}>
       <AdminTitle
         title="콘텐츠 관리"
         description="콘텐츠(단편, 시리즈 에피소드 포함)를 관리합니다."
         action={<AdminVideoContentsUploadButton />}
       />
-
       <div className="px-12 pb-12">{children}</div>
-    </>
+    </RoleGuard>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,8 +3,8 @@ import "./globals.css";
 import Providers from "./provider";
 
 export const metadata: Metadata = {
-  title: "Admin",
-  description: "Admin",
+  title: "O+T Admin",
+  description: "O+T Admin",
 };
 
 export default function RootLayout({

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { CircleAlert } from "lucide-react";
+import { CommonButton } from "@shared/components";
+
+export default function NotFound() {
+  return (
+    <div className="bg-ot-background text-ot-text flex min-h-screen flex-col items-center justify-center gap-4 px-6">
+      <CircleAlert
+        className="text-ot-primary-400 mb-2"
+        size={80}
+        strokeWidth={1.5}
+      />
+
+      <h1 className="text-2xl font-bold tracking-tight">
+        페이지를 찾을 수 없습니다.
+      </h1>
+
+      <p className="text-ot-placeholder mb-4 text-center leading-relaxed">
+        요청하신 페이지가 존재하지 않거나 접근 권한이 없습니다.
+      </p>
+
+      <Link href="/series">
+        <CommonButton variant="primary" className="h-12 px-10 font-semibold">
+          홈으로 가기
+        </CommonButton>
+      </Link>
+    </div>
+  );
+}

--- a/src/entities/auth/apis/loginApi.ts
+++ b/src/entities/auth/apis/loginApi.ts
@@ -9,6 +9,8 @@ export interface AdminLoginRequest {
 export interface AdminLoginResponse {
   memberId: number;
   role: Role;
+  email: string;
+  nickname: string;
 }
 
 export const loginApi = async (body: AdminLoginRequest) => {

--- a/src/entities/auth/apis/loginApi.ts
+++ b/src/entities/auth/apis/loginApi.ts
@@ -1,5 +1,5 @@
 import { api } from "@shared/api";
-import { ApiResponse } from "@shared/types";
+import { ApiResponse, Role } from "@shared/types";
 
 export interface AdminLoginRequest {
   email: string;
@@ -8,10 +8,13 @@ export interface AdminLoginRequest {
 
 export interface AdminLoginResponse {
   memberId: number;
-  role: "ADMIN" | "EDITOR";
+  role: Role;
 }
 
 export const loginApi = async (body: AdminLoginRequest) => {
-  const res = await api.post<ApiResponse<AdminLoginResponse>>("/login", body);
-  return res.data.data;
+  const { data } = await api.post<ApiResponse<AdminLoginResponse>>(
+    "/login",
+    body,
+  );
+  return data.data;
 };

--- a/src/entities/category/apis/getCategories.ts
+++ b/src/entities/category/apis/getCategories.ts
@@ -7,7 +7,6 @@ export interface CategoryResponse {
 }
 
 export const getCategoriespi = async () => {
-  const res =
-    await api.get<ApiResponse<CategoryResponse[]>>("/admin/categories");
+  const res = await api.get<ApiResponse<CategoryResponse[]>>("/categories");
   return res.data.data;
 };

--- a/src/entities/statistics/components/StatisticsRoleGuardWrapper.tsx
+++ b/src/entities/statistics/components/StatisticsRoleGuardWrapper.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { StatisticsContents } from "@entities/statistics/components";
+import { ROLES } from "@shared/constants";
+import { useAuthStore } from "@shared/store";
+
+export function StatisticsRoleGuardWrapper() {
+  const role = useAuthStore((s) => s.role);
+
+  if (role !== ROLES.ADMIN) return null;
+
+  return <StatisticsContents />;
+}

--- a/src/entities/statistics/components/index.ts
+++ b/src/entities/statistics/components/index.ts
@@ -1,3 +1,4 @@
 export { StatisticsContents } from "./StatisticsContents";
 export { CategoryCharts } from "./CategoryCharts";
 export { MonitoringCategoryTabs } from "./MonitoringCategoryTabs";
+export { StatisticsRoleGuardWrapper } from "./StatisticsRoleGuardWrapper";

--- a/src/features/auth-login/components/LoginForm.tsx
+++ b/src/features/auth-login/components/LoginForm.tsx
@@ -17,8 +17,13 @@ export function LoginForm() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const { memberId, role } = await loginApi({ email, password });
-      setAuth(memberId, role); // auth 상태 저장
+      const {
+        memberId,
+        role,
+        email: userEmail,
+        nickname,
+      } = await loginApi({ email, password });
+      setAuth(memberId, role, userEmail, nickname); // auth 상태 저장
 
       router.push("/");
     } catch (error) {

--- a/src/features/auth-login/components/LoginForm.tsx
+++ b/src/features/auth-login/components/LoginForm.tsx
@@ -5,17 +5,20 @@ import { useState } from "react";
 import { loginApi } from "@entities/auth/apis";
 import { EmailField, PasswordField } from "@entities/auth/components";
 import { CommonButton } from "@shared/components";
+import { useAuthStore } from "@shared/store";
 
 export function LoginForm() {
   const router = useRouter();
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [showPassword, setShowPassword] = useState<boolean>(false);
+  const setAuth = useAuthStore((s) => s.setAuth);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await loginApi({ email, password });
+      const { memberId, role } = await loginApi({ email, password });
+      setAuth(memberId, role); // auth 상태 저장
 
       router.push("/");
     } catch (error) {

--- a/src/layouts/AdminSideBar.tsx
+++ b/src/layouts/AdminSideBar.tsx
@@ -52,7 +52,7 @@ const menus = [
 export const AdminSideBar = () => {
   const pathname = usePathname();
   const router = useRouter();
-  const { role, clearAuth } = useAuthStore();
+  const { role, email, nickname, clearAuth } = useAuthStore();
 
   const filteredMenus = menus.filter((menu) =>
     role ? menu.roles.includes(role) : false,
@@ -101,11 +101,8 @@ export const AdminSideBar = () => {
 
       <div className="mt-auto py-3 border-t border-ot-gray-600 px-4 flex items-center justify-between">
         <div>
-          {/* TODO: 실제 user api 데이터 들어갈 자리 */}
-          <p className="font-semibold text-ot-text text-md">
-            {role === "ADMIN" ? "관리자" : "에디터"}
-          </p>
-          <p className="text-ot-placeholder text-sm">-</p>
+          <p className="font-semibold text-ot-text text-md">{nickname}</p>
+          <p className="text-ot-placeholder text-sm">{email}</p>
         </div>
         <button className="cursor-pointer" onClick={handleLogout}>
           <LogOut

--- a/src/layouts/AdminSideBar.tsx
+++ b/src/layouts/AdminSideBar.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { usePathname } from "next/navigation";
-import { logoutApi } from "@/entities/auth/apis";
 import {
   Clapperboard,
   Drama,
@@ -12,6 +11,9 @@ import {
   SquarePlay,
   Users,
 } from "lucide-react";
+import { logoutApi } from "@entities/auth/apis";
+import { ROLES } from "@shared/constants";
+import { useAuthStore } from "@shared/store";
 import { cn } from "@shared/utils";
 
 const menus = [
@@ -19,42 +21,47 @@ const menus = [
     name: "시리즈 관리",
     href: "/series",
     icon: Drama,
+    roles: [ROLES.ADMIN],
   },
   {
     name: "콘텐츠 관리",
     href: "/video-contents",
     icon: Clapperboard,
+    roles: [ROLES.ADMIN],
   },
   {
     name: "숏폼 관리",
     href: "/shorts",
     icon: SquarePlay,
+    roles: [ROLES.ADMIN, ROLES.EDITOR],
   },
   {
     name: "전체 유저 관리",
     href: "/user",
     icon: Users,
+    roles: [ROLES.ADMIN],
   },
   {
     name: "모니터링",
     href: "/monitoring",
     icon: LineChart,
+    roles: [ROLES.ADMIN, ROLES.EDITOR],
   },
 ];
-
-// 실제 user api 데이터 들어갈 자리
-const user = {
-  name: "관리자",
-  email: "ott@gmail.com",
-};
 
 export const AdminSideBar = () => {
   const pathname = usePathname();
   const router = useRouter();
+  const { role, clearAuth } = useAuthStore();
+
+  const filteredMenus = menus.filter((menu) =>
+    role ? menu.roles.includes(role) : false,
+  );
 
   const handleLogout = async () => {
     try {
       await logoutApi();
+      clearAuth();
       router.push("/auth/login");
     } catch (error) {
       alert("로그아웃에 실패했습니다. 다시 시도해주세요.");
@@ -65,12 +72,12 @@ export const AdminSideBar = () => {
     <aside className="flex flex-col bg-ot-gray-800 w-1/7">
       <Link href="/series" className="block ml-3 my-4 px-3">
         <span className="font-bold text-3xl text-ot-text hover:text-ot-gray-600">
-          O+T 관리자
+          O+T 관리
         </span>
       </Link>
 
       <nav className="flex flex-col px-3">
-        {menus.map((menu) => {
+        {filteredMenus.map((menu) => {
           const isActive = pathname.startsWith(menu.href);
           const Icon = menu.icon;
 
@@ -91,10 +98,14 @@ export const AdminSideBar = () => {
           );
         })}
       </nav>
+
       <div className="mt-auto py-3 border-t border-ot-gray-600 px-4 flex items-center justify-between">
         <div>
-          <p className="font-semibold text-ot-text text-md">{user.name}</p>
-          <p className="text-ot-placeholder text-sm">{user.email}</p>
+          {/* TODO: 실제 user api 데이터 들어갈 자리 */}
+          <p className="font-semibold text-ot-text text-md">
+            {role === "ADMIN" ? "관리자" : "에디터"}
+          </p>
+          <p className="text-ot-placeholder text-sm">-</p>
         </div>
         <button className="cursor-pointer" onClick={handleLogout}>
           <LogOut

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -26,9 +26,10 @@ export function proxy(request: NextRequest) {
   if (isDev) {
     return NextResponse.next();
   }
-  const accessToken = request.cookies.get("accessToken")?.value;
+  // const accessToken = request.cookies.get("accessToken")?.value;
   const refreshToken = request.cookies.get("refreshToken")?.value;
-  if (!accessToken || !refreshToken) {
+
+  if (!refreshToken) {
     return NextResponse.redirect(new URL("/auth/login", request.url));
   }
   return NextResponse.next();

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -28,7 +28,7 @@ export function proxy(request: NextRequest) {
   }
   const accessToken = request.cookies.get("accessToken")?.value;
   const refreshToken = request.cookies.get("refreshToken")?.value;
-  if (!accessToken && !refreshToken) {
+  if (!accessToken || !refreshToken) {
     return NextResponse.redirect(new URL("/auth/login", request.url));
   }
   return NextResponse.next();

--- a/src/shared/components/RoleGuard.tsx
+++ b/src/shared/components/RoleGuard.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useAuthStore } from "@shared/store";
+import { Role } from "@shared/types";
+
+interface RoleGuardProps {
+  children: React.ReactNode;
+  allowedRole: Role[];
+  redirectTo?: string;
+}
+
+export function RoleGuard({
+  children,
+  allowedRole,
+  redirectTo = "/shorts",
+}: RoleGuardProps) {
+  const role = useAuthStore((s) => s.role);
+  const router = useRouter();
+  const [isHydrated, setIsHydrated] = useState<boolean>(false);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (isHydrated && role && !allowedRole.includes(role)) {
+      router.replace(redirectTo);
+    }
+  }, [role, isHydrated]);
+
+  if (!isHydrated) {
+    return (
+      <div className="flex items-center justify-center w-full h-full">
+        <p className="text-ot-placeholder text-sm">로딩 중...</p>
+      </div>
+    );
+  }
+
+  // role은 있는데 권한 없는 경우 에러처리
+  if (!role || !allowedRole.includes(role)) {
+    return (
+      <div className="flex flex-col items-center justify-center w-full h-full gap-2">
+        <p className="text-ot-text font-semibold">접근 권한이 없습니다.</p>
+        <p className="text-ot-placeholder text-sm">
+          해당 페이지에 접근할 수 없습니다.
+        </p>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -11,3 +11,4 @@ export { AdminPosterUpload } from "./AdminPosterUpload";
 export { AdminPublicBadge } from "./AdminPublicBadge";
 export { ConfirmModal } from "./ConfirmModal";
 export type { PosterState } from "./AdminPosterUpload";
+export { RoleGuard } from "./RoleGuard";

--- a/src/shared/constants/auth.ts
+++ b/src/shared/constants/auth.ts
@@ -1,0 +1,6 @@
+import { Role } from "@shared/types";
+
+export const ROLES: Record<string, Role> = {
+  ADMIN: "ADMIN",
+  EDITOR: "EDITOR",
+} as const;

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,1 +1,2 @@
+export { ROLES } from "./auth";
 export { MAX_FILE_SIZE, MIN_FILE_SIZE } from "./fileSize";

--- a/src/shared/store/index.ts
+++ b/src/shared/store/index.ts
@@ -1,0 +1,1 @@
+export * from "./useAuthStore";

--- a/src/shared/store/useAuthStore.ts
+++ b/src/shared/store/useAuthStore.ts
@@ -1,0 +1,22 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { Role } from "@shared/types";
+
+interface AuthState {
+  memberId: number | null;
+  role: Role | null;
+  setAuth: (memberId: number, role: Role) => void;
+  clearAuth: () => void;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      memberId: null,
+      role: null,
+      setAuth: (memberId, role) => set({ memberId, role }),
+      clearAuth: () => set({ memberId: null, role: null }),
+    }),
+    { name: "auth-storage" },
+  ),
+);

--- a/src/shared/store/useAuthStore.ts
+++ b/src/shared/store/useAuthStore.ts
@@ -28,6 +28,12 @@ export const useAuthStore = create<AuthState>()(
       clearAuth: () =>
         set({ memberId: null, role: null, email: null, nickname: null }),
     }),
-    { name: "auth-storage" },
+    {
+      name: "auth-storage",
+      partialize: (state) => ({
+        memberId: state.memberId,
+        role: state.role,
+      }),
+    },
   ),
 );

--- a/src/shared/store/useAuthStore.ts
+++ b/src/shared/store/useAuthStore.ts
@@ -5,7 +5,14 @@ import { Role } from "@shared/types";
 interface AuthState {
   memberId: number | null;
   role: Role | null;
-  setAuth: (memberId: number, role: Role) => void;
+  email: string | null;
+  nickname: string | null;
+  setAuth: (
+    memberId: number,
+    role: Role,
+    email: string,
+    nickname: string,
+  ) => void;
   clearAuth: () => void;
 }
 
@@ -14,8 +21,12 @@ export const useAuthStore = create<AuthState>()(
     (set) => ({
       memberId: null,
       role: null,
-      setAuth: (memberId, role) => set({ memberId, role }),
-      clearAuth: () => set({ memberId: null, role: null }),
+      email: null,
+      nickname: null,
+      setAuth: (memberId, role, email, nickname) =>
+        set({ memberId, role, email, nickname }),
+      clearAuth: () =>
+        set({ memberId: null, role: null, email: null, nickname: null }),
     }),
     { name: "auth-storage" },
   ),

--- a/src/shared/types/auth.ts
+++ b/src/shared/types/auth.ts
@@ -1,0 +1,1 @@
+export type Role = "ADMIN" | "EDITOR";

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -7,3 +7,4 @@ export * from "./videoFileMeta";
 export type { ApiError } from "./apiError";
 export type { ApiResponse } from "./apiResponse";
 export type { PageInfo, BasePaginationParams } from "./pagination";
+export type { Role } from "./auth";


### PR DESCRIPTION
## 📝 작업 내용

> **구현**
> - 로그인 시 auth 정보를 전역 상태관리에 추가 (zustand)
> - role 기반 RoleGuard 컴포넌트 추가
>    - editor가 다른 도메인 접근 시 `/shorts`로 강제 redirect
> - not-found 컴포넌트 추가
> - editor 권한: 사이드바 조건부렌더링 (숏폼 관리, 모니터링만 렌더링)
> 
> **수정**
> - `/categories` 엔드포인트 수정
> - proxy token 조건 수정 (token 둘 중 하나라도 없으면 `/auth/login`으로 redirect)



## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. src에 이미지 url만 등록하면 됩니다. -->

| 구현 내용 |             관리자 정보 - 좌측하단              |        
| :-------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/bacbe1ea-9586-4f58-a35b-831d45b1a2b2" width ="700"> | 

| 구현 내용 |             에디터 - 숏폼관리              |        
| :-------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/98ee5db2-7e54-4ce9-939c-9b63300f1f67" width ="700"> | 


| 구현 내용 |             에디터 - 모니터링              |        
| :-------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/d1e744e9-a290-42e7-9aa8-2d36f3ae17b6" width ="700"> | 


## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`useAuthStore.ts`

- 로그인 정보를 전역상태에 저장하여 role 별 도메인 접근 권한을 관리합니다.

```ts
export const useAuthStore = create<AuthState>()(
  persist(
    (set) => ({
      memberId: null,
      role: null,
      email: null,
      nickname: null,
      setAuth: (memberId, role, email, nickname) =>
        set({ memberId, role, email, nickname }),
      clearAuth: () =>
        set({ memberId: null, role: null, email: null, nickname: null }),
    }),
    { name: "auth-storage" },
  ),
);
```

## ☑️ 체크 리스트

> 체크 리스트를 확인해주세요

- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?

## #️⃣ 연관된 이슈

> ex) #41 

## 💬 리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 역할 기반 접근 제어 추가로 관리 페이지 및 특정 레이아웃에 권한 제한 적용
  * 404(페이지 없음) 화면 추가
  * 통계 섹션 표시를 관리자 전용으로 제한

* **개선 사항**
  * 사이드바 메뉴를 사용자 역할에 따라 필터링하여 가시성 제어
  * 로그인 시 이메일·닉네임 등 사용자 정보 저장(영속화)
  * 루트 메타데이터 제목/설명 업데이트("Admin" → "O+T Admin")
  * 인증 토큰 검사 로직 일부 간소화 및 카테고리 API 경로 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->